### PR TITLE
SQL File-Based Migrations (SPEC-0022)

### DIFF
--- a/internal/db/migrations/00001_initial_schema.sql
+++ b/internal/db/migrations/00001_initial_schema.sql
@@ -1,0 +1,63 @@
+-- +goose Up
+CREATE TABLE sessions (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    tier INTEGER NOT NULL,
+    model TEXT NOT NULL,
+    prompt_file TEXT NOT NULL,
+    status TEXT NOT NULL,
+    started_at TEXT NOT NULL,
+    ended_at TEXT,
+    exit_code INTEGER,
+    log_file TEXT,
+    context TEXT
+);
+
+CREATE TABLE health_checks (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    session_id INTEGER REFERENCES sessions(id),
+    service TEXT NOT NULL,
+    check_type TEXT NOT NULL,
+    status TEXT NOT NULL,
+    response_time_ms INTEGER,
+    error_detail TEXT,
+    checked_at TEXT NOT NULL
+);
+
+CREATE TABLE cooldown_actions (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    service TEXT NOT NULL,
+    action_type TEXT NOT NULL,
+    timestamp TEXT NOT NULL,
+    success INTEGER NOT NULL,
+    tier INTEGER NOT NULL,
+    error TEXT,
+    session_id INTEGER REFERENCES sessions(id)
+);
+
+CREATE TABLE service_health_streak (
+    service TEXT PRIMARY KEY,
+    consecutive_healthy INTEGER NOT NULL DEFAULT 0,
+    last_checked_at TEXT
+);
+
+CREATE TABLE config (
+    key TEXT PRIMARY KEY,
+    value TEXT NOT NULL,
+    updated_at TEXT NOT NULL DEFAULT (datetime('now'))
+);
+
+CREATE INDEX idx_health_checks_service ON health_checks(service, checked_at);
+CREATE INDEX idx_health_checks_session ON health_checks(session_id);
+CREATE INDEX idx_cooldown_actions_service ON cooldown_actions(service, action_type, timestamp);
+CREATE INDEX idx_sessions_status ON sessions(status, started_at);
+
+-- +goose Down
+DROP INDEX IF EXISTS idx_sessions_status;
+DROP INDEX IF EXISTS idx_cooldown_actions_service;
+DROP INDEX IF EXISTS idx_health_checks_session;
+DROP INDEX IF EXISTS idx_health_checks_service;
+DROP TABLE IF EXISTS config;
+DROP TABLE IF EXISTS service_health_streak;
+DROP TABLE IF EXISTS cooldown_actions;
+DROP TABLE IF EXISTS health_checks;
+DROP TABLE IF EXISTS sessions;

--- a/internal/db/migrations/00002_session_metadata.sql
+++ b/internal/db/migrations/00002_session_metadata.sql
@@ -1,0 +1,11 @@
+-- +goose Up
+ALTER TABLE sessions ADD COLUMN response TEXT;
+ALTER TABLE sessions ADD COLUMN cost_usd REAL;
+ALTER TABLE sessions ADD COLUMN num_turns INTEGER;
+ALTER TABLE sessions ADD COLUMN duration_ms INTEGER;
+
+-- +goose Down
+ALTER TABLE sessions DROP COLUMN duration_ms;
+ALTER TABLE sessions DROP COLUMN num_turns;
+ALTER TABLE sessions DROP COLUMN cost_usd;
+ALTER TABLE sessions DROP COLUMN response;

--- a/internal/db/migrations/00003_session_trigger.sql
+++ b/internal/db/migrations/00003_session_trigger.sql
@@ -1,0 +1,7 @@
+-- +goose Up
+ALTER TABLE sessions ADD COLUMN trigger TEXT NOT NULL DEFAULT 'scheduled';
+ALTER TABLE sessions ADD COLUMN prompt_text TEXT;
+
+-- +goose Down
+ALTER TABLE sessions DROP COLUMN prompt_text;
+ALTER TABLE sessions DROP COLUMN trigger;

--- a/internal/db/migrations/00004_events.sql
+++ b/internal/db/migrations/00004_events.sql
@@ -1,0 +1,19 @@
+-- +goose Up
+CREATE TABLE events (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    session_id INTEGER REFERENCES sessions(id),
+    level TEXT NOT NULL,
+    service TEXT,
+    message TEXT NOT NULL,
+    created_at TEXT NOT NULL
+);
+
+CREATE INDEX idx_events_created ON events(created_at);
+CREATE INDEX idx_events_session ON events(session_id);
+CREATE INDEX idx_events_level ON events(level, created_at);
+
+-- +goose Down
+DROP INDEX IF EXISTS idx_events_level;
+DROP INDEX IF EXISTS idx_events_session;
+DROP INDEX IF EXISTS idx_events_created;
+DROP TABLE IF EXISTS events;

--- a/internal/db/migrations/00005_escalation_chain.sql
+++ b/internal/db/migrations/00005_escalation_chain.sql
@@ -1,0 +1,7 @@
+-- +goose Up
+ALTER TABLE sessions ADD COLUMN parent_session_id INTEGER REFERENCES sessions(id);
+CREATE INDEX idx_sessions_parent ON sessions(parent_session_id);
+
+-- +goose Down
+DROP INDEX IF EXISTS idx_sessions_parent;
+ALTER TABLE sessions DROP COLUMN parent_session_id;

--- a/internal/db/migrations/00006_memories.sql
+++ b/internal/db/migrations/00006_memories.sql
@@ -1,0 +1,23 @@
+-- +goose Up
+CREATE TABLE memories (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    service TEXT,
+    category TEXT NOT NULL,
+    observation TEXT NOT NULL,
+    confidence REAL NOT NULL DEFAULT 0.7,
+    active INTEGER NOT NULL DEFAULT 1,
+    created_at TEXT NOT NULL,
+    updated_at TEXT NOT NULL,
+    session_id INTEGER REFERENCES sessions(id),
+    tier INTEGER NOT NULL DEFAULT 1
+);
+
+CREATE INDEX idx_memories_service ON memories(service, active);
+CREATE INDEX idx_memories_confidence ON memories(confidence, active);
+CREATE INDEX idx_memories_category ON memories(category);
+
+-- +goose Down
+DROP INDEX IF EXISTS idx_memories_category;
+DROP INDEX IF EXISTS idx_memories_confidence;
+DROP INDEX IF EXISTS idx_memories_service;
+DROP TABLE IF EXISTS memories;

--- a/internal/db/migrations/00007_session_summary.sql
+++ b/internal/db/migrations/00007_session_summary.sql
@@ -1,0 +1,5 @@
+-- +goose Up
+ALTER TABLE sessions ADD COLUMN summary TEXT;
+
+-- +goose Down
+ALTER TABLE sessions DROP COLUMN summary;


### PR DESCRIPTION
Create internal/db/migrations/ directory with all 7 goose SQL migration files.

## Changes
- Create `internal/db/migrations/00001_initial_schema.sql`
- Create `internal/db/migrations/00002_session_metadata.sql`
- Create `internal/db/migrations/00003_session_trigger.sql`
- Create `internal/db/migrations/00004_events.sql`
- Create `internal/db/migrations/00005_escalation_chain.sql`
- Create `internal/db/migrations/00006_memories.sql`
- Create `internal/db/migrations/00007_session_summary.sql`

Each file contains `-- +goose Up` (DDL extracted verbatim from Go functions) and `-- +goose Down` (reversal DDL) sections.

No Go code was changed — only new SQL files added.

Closes #204
Closes #207
Closes #222
Part of #195 (SPEC-0022)

---
*Governing: SPEC-0022 REQ "SQL File-Based Migrations", "Existing Migration Conversion", "Down Migration Support"*