### PR TITLE
Bootstrap from Legacy Tracking Table (SPEC-0022)

### DIFF
--- a/internal/db/bootstrap.go
+++ b/internal/db/bootstrap.go
@@ -1,0 +1,66 @@
+package db
+
+import (
+	"database/sql"
+	"fmt"
+)
+
+// Governing: SPEC-0022 REQ "Bootstrap from Legacy Tracking Table"
+func bootstrapFromLegacy(conn *sql.DB) error {
+	// Check if legacy table exists
+	var count int
+	err := conn.QueryRow(
+		`SELECT COUNT(*) FROM sqlite_master WHERE type='table' AND name='schema_migrations'`,
+	).Scan(&count)
+	if err != nil {
+		return fmt.Errorf("check legacy table: %w", err)
+	}
+	if count == 0 {
+		return nil // Fresh database, no bootstrap needed
+	}
+
+	// Check if goose table already exists (already bootstrapped)
+	err = conn.QueryRow(
+		`SELECT COUNT(*) FROM sqlite_master WHERE type='table' AND name='goose_db_version'`,
+	).Scan(&count)
+	if err != nil {
+		return fmt.Errorf("check goose table: %w", err)
+	}
+	if count > 0 {
+		return nil // Already bootstrapped
+	}
+
+	// Read max version from legacy table
+	var maxVersion int
+	err = conn.QueryRow(`SELECT COALESCE(MAX(version), 0) FROM schema_migrations`).Scan(&maxVersion)
+	if err != nil {
+		return fmt.Errorf("read legacy version: %w", err)
+	}
+	if maxVersion == 0 {
+		return nil // No migrations applied in legacy system
+	}
+
+	// Create goose tracking table
+	_, err = conn.Exec(`CREATE TABLE goose_db_version (
+		id INTEGER PRIMARY KEY AUTOINCREMENT,
+		version_id INTEGER NOT NULL,
+		is_applied INTEGER NOT NULL,
+		tstamp TEXT NOT NULL DEFAULT (datetime('now'))
+	)`)
+	if err != nil {
+		return fmt.Errorf("create goose_db_version: %w", err)
+	}
+
+	// Insert a row for each applied legacy version
+	for v := 1; v <= maxVersion; v++ {
+		_, err = conn.Exec(
+			`INSERT INTO goose_db_version (version_id, is_applied, tstamp) VALUES (?, 1, datetime('now'))`,
+			v,
+		)
+		if err != nil {
+			return fmt.Errorf("insert goose version %d: %w", v, err)
+		}
+	}
+
+	return nil
+}


### PR DESCRIPTION
Add bootstrapFromLegacy() function for one-time migration from schema_migrations to goose_db_version.

## Changes
- Add `bootstrapFromLegacy(conn *sql.DB) error` function to `internal/db/bootstrap.go`
- Function checks for legacy `schema_migrations` table and migrates version state to `goose_db_version`
- Fully idempotent: safe to call on fresh databases, legacy databases, and already-bootstrapped databases

## Behavior
- Fresh database (no schema_migrations): no-op, returns nil
- Legacy database with schema_migrations at version 7: creates goose_db_version and inserts versions 1-7
- Already bootstrapped (goose_db_version exists): no-op, returns nil
- Partial legacy state (e.g., version 5): inserts rows 1-5, goose then applies 6 and 7

## Notes
This PR adds the bootstrap function only — it is not yet wired into db.Open(). That integration happens in #214 (Goose Provider API Integration). This function uses only standard library SQL and does not require the goose package.

Closes #216
Part of #195 (SPEC-0022)

---
*Governing: SPEC-0022 REQ "Bootstrap from Legacy Tracking Table"*