### PR TITLE
Summary Persistence (SPEC-0021)

### DIFF
--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -32,7 +32,7 @@ type Session struct {
 	Trigger         string  // "scheduled" or "manual"
 	PromptText      *string // custom prompt text for ad-hoc sessions
 	ParentSessionID *int64  // links to parent session for escalation chains
-	Summary         *string // LLM-generated summary of session response
+	Summary         *string // LLM-generated summary of session response — Governing: SPEC-0021 REQ "Summary Persistence"
 }
 
 // HealthCheck represents a parsed health check result.
@@ -894,6 +894,7 @@ func (d *DB) DecayStaleMemories(graceDays int, decayRate float64) error {
 	return nil
 }
 
+// Governing: SPEC-0021 REQ "Summary Persistence"
 func migrate007(tx *sql.Tx) error {
 	_, err := tx.Exec(`ALTER TABLE sessions ADD COLUMN summary TEXT`)
 	if err != nil {
@@ -903,6 +904,7 @@ func migrate007(tx *sql.Tx) error {
 }
 
 // UpdateSessionSummary stores an LLM-generated summary for a session.
+// Governing: SPEC-0021 REQ "Summary Persistence"
 func (d *DB) UpdateSessionSummary(id int64, summary string) error {
 	_, err := d.conn.Exec(`UPDATE sessions SET summary = ? WHERE id = ?`, summary, id)
 	if err != nil {


### PR DESCRIPTION
## Summary

Adds a nullable `summary` TEXT column to the `sessions` table via migration 007.

- Migration 007 adds `summary TEXT` (nullable) to `sessions`
- `Session` struct includes `Summary *string` field
- `UpdateSessionSummary()` helper for writing summaries after generation
- `sessionColumns` and `scanSession` include the summary column
- Governing comments reference SPEC-0021 REQ "Summary Persistence"

## Test plan

- [x] `TestMigration007Summary` verifies column exists
- [x] `TestUpdateSessionSummary` verifies write/read roundtrip and null default
- [x] All existing tests pass (`go test ./... -count=1 -race`)
- [x] Lint passes (`go vet ./...` and `golangci-lint run`)

Governing: SPEC-0021 REQ "Summary Persistence"

Closes #174
Part of #162 (SPEC-0021)

🤖 Generated with [Claude Code](https://claude.com/claude-code)