### PR TITLE
Summarization Model Configuration (SPEC-0021)

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -26,7 +26,8 @@ type Config struct {
 	MemoryBudget          int
 	BrowserAllowedOrigins string
 	PREnabled             bool
-	SummaryModel          string
+	// Governing: SPEC-0021 REQ "Summarization Model"
+	SummaryModel string
 }
 
 // Load reads configuration from viper, which merges flag values, env vars,

--- a/internal/session/summarize.go
+++ b/internal/session/summarize.go
@@ -12,6 +12,7 @@ const summarizeSystemPrompt = "You are a concise technical summarizer. Summarize
 // summarizeResponse calls the Anthropic Messages API to generate a short
 // plain-text summary of a session response. The model parameter should be
 // an Anthropic model identifier (e.g. "haiku").
+// Governing: SPEC-0021 REQ "Summarization Model"
 func summarizeResponse(ctx context.Context, response string, model string) (string, error) {
 	client := anthropic.NewClient()
 


### PR DESCRIPTION
## Summary

- Adds SPEC-0021 governing comments to `CLAUDEOPS_SUMMARY_MODEL` config and `summarizeResponse` function
- The config itself (env var, CLI flag, viper binding, default "haiku") was already implemented in prior commits
- Governing comments trace implementation back to SPEC-0021 REQ "Summarization Model"

### What was already in place

| Component | Location | Detail |
|-----------|----------|--------|
| Config struct field | `internal/config/config.go:29` | `SummaryModel string` |
| Viper loading | `internal/config/config.go:55` | `viper.GetString("summary_model")` |
| CLI flag | `cmd/claudeops/main.go:56` | `--summary-model` default `"haiku"` |
| Env var | `cmd/claudeops/main.go:87-88` | `CLAUDEOPS_SUMMARY_MODEL` via AutomaticEnv |
| Usage | `internal/session/manager.go:410` | Passed to `summarizeResponse()` |

Governing: SPEC-0021 REQ "Summarization Model"

Closes #185
Part of #162 (SPEC-0021)