### PR TITLE
TL;DR Page Rendering (SPEC-0021)

### DIFF
--- a/internal/web/handlers.go
+++ b/internal/web/handlers.go
@@ -16,6 +16,7 @@ import (
 )
 
 // handleIndex renders the overview dashboard.
+// Governing: SPEC-0021 REQ "TL;DR Page Rendering"
 func (s *Server) handleIndex(w http.ResponseWriter, r *http.Request) {
 	var sessionView *SessionView
 	if latest, err := s.db.LatestSession(); err != nil {

--- a/internal/web/templates/index.html
+++ b/internal/web/templates/index.html
@@ -1,3 +1,4 @@
+{{/* Governing: SPEC-0021 REQ "TL;DR Page Rendering" */}}
 {{define "index.html"}}
 <div class="max-w-6xl" id="overview-content">
     <h1 class="text-2xl font-semibold mb-6">TL;DR</h1>


### PR DESCRIPTION
## Summary

Renames the dashboard Overview page to TL;DR and displays session summary with markdown fallback.

- Page heading reads "TL;DR", sidebar nav shows "🤔 TL;DR"
- When summary available: displays summary text
- When summary NULL: falls back to full rendered markdown response
- Added `TestTLDRPageRendering` and `TestTLDRFallbackToResponse` tests
- Governing comments on `handleIndex`, `index.html` template, and tests

## Test plan

- [x] `TestTLDRPageRendering` verifies heading, emoji, summary display
- [x] `TestTLDRFallbackToResponse` verifies markdown fallback when summary is NULL
- [x] All tests pass (`go test ./... -count=1 -race`)
- [x] Lint passes (`go vet ./...` and `golangci-lint run`)

Governing: SPEC-0021 REQ "TL;DR Page Rendering"

Closes #179
Part of #162 (SPEC-0021)

🤖 Generated with [Claude Code](https://claude.com/claude-code)