### PR TITLE
Add persistent volumes and env configuration (SPEC-0009)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,11 +1,47 @@
+# Governing: SPEC-0009 REQ "Environment-Based Configuration"
+#
+# All runtime configuration is provided through environment variables.
+# Copy this file to .env and fill in your values.
+#   cp .env.example .env
+
+# Required: Anthropic API key (no default)
 ANTHROPIC_API_KEY=
+
+# Optional: Custom Anthropic-compatible base URL
 # ANTHROPIC_BASE_URL=https://litellm.example.com
-CLAUDEOPS_DRY_RUN=true
+
+# Optional: Interval between watchdog runs in seconds (default: 3600)
 CLAUDEOPS_INTERVAL=900
+
+# Optional: Dry run mode — observe only, never remediate (default: false)
+CLAUDEOPS_DRY_RUN=true
+
+# Optional: Tiered model escalation (default: haiku / sonnet / opus)
+# CLAUDEOPS_TIER1_MODEL=haiku
+# CLAUDEOPS_TIER2_MODEL=sonnet
+# CLAUDEOPS_TIER3_MODEL=opus
+
+# Optional: Maximum escalation tier (default: 3)
+# CLAUDEOPS_MAX_TIER=3
+
+# Optional: Custom prompt files for escalation tiers
+# CLAUDEOPS_TIER2_PROMPT=prompts/tier2-investigate.md
+# CLAUDEOPS_TIER3_PROMPT=prompts/tier3-remediate.md
+
 # Governing: SPEC-0004 REQ-1 (single env var for all notification targets)
 # Comma-separated Apprise URLs. Unset = notifications silently skipped (REQ-2).
+# Supports 80+ services: ntfy, Slack, Discord, Telegram, email, etc.
 # CLAUDEOPS_APPRISE_URLS=
-# CLAUDEOPS_SUMMARY_MODEL=haiku
+
+# Optional: Allowed origins for browser automation (default: empty)
 # CLAUDEOPS_BROWSER_ALLOWED_ORIGINS=
+
+# Optional: Enable PR creation for remediation (default: false)
+# CLAUDEOPS_PR_ENABLED=false
+
+# Optional: Browser credential injection for web UI checks
 # BROWSER_CRED_SONARR_USER=
 # BROWSER_CRED_SONARR_PASS=
+
+# Optional: Summary model for digest reports
+# CLAUDEOPS_SUMMARY_MODEL=haiku

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -7,6 +7,7 @@ services:
     container_name: claude-ops            # Governing: SPEC-0009 REQ-3 "container_name: claude-ops"
     restart: unless-stopped               # Governing: SPEC-0009 REQ-3, REQ-7 "Restart policy and resilience", ADR-0009
     # Governing: SPEC-0009 REQ-3, REQ-6 "Environment-based configuration"
+    # Governing: SPEC-0009 REQ "Restart Policy and Resilience", REQ "Environment-Based Configuration"
     environment:
       - ANTHROPIC_API_KEY=${ANTHROPIC_API_KEY}
       - ANTHROPIC_BASE_URL=${ANTHROPIC_BASE_URL:-}
@@ -25,6 +26,7 @@ services:
       - "8080:8080"
     # Governing: SPEC-0007 REQ-3 — state directory backed by bind mount, persists across restarts/rebuilds
     # Governing: SPEC-0009 REQ-3, REQ-4 "Persistent volume mounts"
+    # Governing: SPEC-0009 REQ "Persistent Volume Mounts"
     volumes:
       - ./state:/state
       - ./results:/results


### PR DESCRIPTION
## Summary

- Add SPEC-0009 governing comments to `docker-compose.yaml` for both the volume mounts section (REQ-4: "Persistent Volume Mounts") and the environment section (REQ-6: "Environment-Based Configuration")
- Expand `.env.example` to document **all** supported environment variables with their defaults, including tier model config (`CLAUDEOPS_TIER1/2/3_MODEL`), prompt overrides, max tier, Apprise URLs, and PR creation toggle
- `state/` and `results/` directories with `.gitkeep` already exist (no changes needed)

## Compliance

| Requirement | Status |
|-------------|--------|
| REQ-4: Persistent volume mounts (`./state:/state`, `./results:/results`) | Already compliant, governing comment added |
| REQ-4: Read-only repo mounts (`:ro` suffix in examples) | Already compliant |
| REQ-6: All env vars documented in `.env.example` | Fixed -- was missing tier models, prompts, max tier, PR enabled |
| REQ-6: `${VAR:-default}` syntax in compose file | Already compliant |

## Test plan

- [x] `go vet` passes (pre-existing `MigrationFS` error in `internal/db` unrelated to these changes)
- [x] `go test` passes on non-db packages
- [x] Verified `state/.gitkeep` and `results/.gitkeep` exist
- [x] Verified `docker-compose.yaml` volume mounts match spec requirements
- [x] Verified all 7 required env vars from REQ-6 are documented with correct defaults

Closes #322 / Part of epic #83 / Part of SPEC-0009

🤖 Generated with [Claude Code](https://claude.com/claude-code)