### PR TITLE
Add SPEC-0009 governing comments to Dockerfile, CI/CD, and Compose

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -83,11 +83,12 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
+  # Governing: SPEC-0009 REQ "CI/CD Image Publishing" — build, push to GHCR, tag with semver and branch
   release:
     name: Release Container
     needs: [lint, test, build]
     runs-on: ubuntu-latest
-    if: github.event_name == 'push'
+    if: github.event_name == 'push'  # Triggers on main branch push and version tag push
     permissions:
       contents: read
       packages: write
@@ -101,7 +102,7 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
-      - name: Log in to GitHub Container Registry
+      - name: Log in to GitHub Container Registry  # Governing: SPEC-0009 REQ "CI/CD Image Publishing" — push to GHCR
         uses: docker/login-action@v3
         with:
           registry: ${{ env.REGISTRY }}
@@ -117,6 +118,7 @@ jobs:
             echo "value=${{ github.ref_name }}-$(echo ${{ github.sha }} | cut -c1-7)" >> "$GITHUB_OUTPUT"
           fi
 
+      # Governing: SPEC-0009 REQ "CI/CD Image Publishing" — semantic version tags + main branch tags
       - name: Extract metadata (tags, labels)
         id: meta
         uses: docker/metadata-action@v5

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,9 +13,10 @@ COPY api/ api/
 RUN CGO_ENABLED=0 go build -ldflags "-X github.com/joestump/claude-ops/internal/config.Version=${VERSION}" -o /claudeops ./cmd/claudeops
 
 # Runtime stage
+# Governing: SPEC-0009 REQ "Dockerfile Structure" — node:22-slim base image
 FROM node:22-slim
 
-# System dependencies for health checks and remediation
+# Governing: SPEC-0009 REQ "Dockerfile Structure" — system dependencies
 RUN apt-get update && apt-get install -y --no-install-recommends \
     openssh-client \
     curl \
@@ -27,14 +28,14 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     && rm -rf /var/lib/apt/lists/*
 
 # Governing: SPEC-0004 REQ-8 (Docker Image Installation — apprise via pip3)
+# Governing: SPEC-0009 REQ "Dockerfile Structure" — apprise for notifications
 # Apprise for notifications (supports 80+ services)
 RUN pip3 install --break-system-packages --retries 3 --timeout 120 apprise
 
-# Governing: SPEC-0010 REQ-1 (CLI Installation via npm — globally installed, available on PATH)
-# Claude Code CLI
+# Governing: SPEC-0010 REQ-1 (CLI Installation via npm), SPEC-0009 REQ "Dockerfile Structure" — Claude Code CLI
 RUN npm install -g @anthropic-ai/claude-code
 
-# Working directory — this repo gets copied in
+# Governing: SPEC-0009 REQ "Dockerfile Structure" — working directory /app
 WORKDIR /app
 
 # Copy Go binary from build stage
@@ -43,7 +44,13 @@ COPY --from=builder /claudeops /claudeops
 # Copy project files (prompts, checks, playbooks, etc.)
 COPY . .
 
-# State and results directories (mount volumes over these)
+# Governing: SPEC-0009 REQ "Dockerfile Structure" — /state, /results, /repos directories
 RUN mkdir -p /state /results /repos
 
+# Governing: SPEC-0009 REQ "Dockerfile Structure" — container entrypoint
+# NOTE: The spec (REQ-9) references entrypoint.sh, which was the original entrypoint.
+# The Go binary /claudeops has since replaced entrypoint.sh entirely — it handles config
+# loading, MCP config merging, session scheduling, signal handling, and the web dashboard.
+# See ADR-0009 (Go rewrite) and cmd/claudeops/main.go. entrypoint.sh is retained for
+# reference but is not used.
 ENTRYPOINT ["/claudeops"]

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -29,7 +29,8 @@ services:
       - ./state:/state
       - ./results:/results
       # Governing: SPEC-0009 REQ-10 "SSH key mounting for remote access"
-      # Mount SSH keys for remote host access (container inspection, logs, remediation)
+      # Mount SSH keys for remote host access (container inspection, logs, remediation).
+      # Keys MUST be mounted read-only (:ro).
       # - ~/.ssh/id_ed25519:/root/.ssh/id_ed25519:ro
       # - ~/.ssh/known_hosts:/root/.ssh/known_hosts:ro
       # Governing: SPEC-0009 REQ-4 "repos mount from operator-specified host paths"
@@ -41,13 +42,13 @@ services:
   # Headless Chrome sidecar for browser automation (credential rotation, web UI checks).
   # Only starts when using: docker compose --profile browser up -d
   chrome:
-    image: browserless/chromium
+    image: browserless/chromium  # Governing: SPEC-0009 REQ "Optional Browser Sidecar via Profiles" — browserless/chromium image
     container_name: claude-ops-chrome
-    restart: unless-stopped               # Governing: SPEC-0009 REQ-7 "browser sidecar restart policy", ADR-0009
+    restart: unless-stopped               # Governing: SPEC-0009 REQ-7 "browser sidecar restart policy", REQ-5 "Optional Browser Sidecar via Profiles", ADR-0009
     profiles:
-      - browser
+      - browser  # Governing: SPEC-0009 REQ "Optional Browser Sidecar via Profiles" — browser profile
     ports:
-      - "9222:9222"
+      - "9222:9222"  # Governing: SPEC-0009 REQ "Optional Browser Sidecar via Profiles" — CDP port 9222
     environment:
       - CONNECTION_TIMEOUT=120000
       # Governing: SPEC-0014 REQ "Isolated Browser Contexts"


### PR DESCRIPTION
## Summary

- Adds SPEC-0009 governing comments to `Dockerfile` for REQ-9 (Dockerfile Structure): base image, system dependencies, apprise, Claude Code CLI, working directory, directories, and entrypoint
- Adds SPEC-0009 governing comments to `docker-compose.yaml` for REQ-5 (Optional Browser Sidecar via Profiles) and REQ-10 (SSH Key Mounting for Remote Access)
- Adds SPEC-0009 governing comments to `.github/workflows/ci.yaml` for REQ-8 (CI/CD Image Publishing): GHCR push, semantic version tagging, main branch tagging
- Documents the spec gap resolution: Go binary `/claudeops` has replaced `entrypoint.sh` as the container entrypoint (REQ-9 references entrypoint.sh but the Go binary is the correct entrypoint)

No functional changes — only governing comments added.

Closes #324 / Part of epic #83 / Part of SPEC-0009

## Test plan

- [ ] Verify `Dockerfile` builds successfully (`docker build .`)
- [ ] Verify `docker compose up -d` starts the watchdog without the browser sidecar
- [ ] Verify `docker compose --profile browser up -d` starts both watchdog and chrome
- [ ] Verify CI/CD pipeline passes (no YAML syntax issues from added comments)

**Pre-existing issue:** `go vet ./...` fails on `internal/db/db.go:111` with `undefined: MigrationFS` — this is a known issue on `main` (from in-progress SPEC-0022 work) and is not related to changes in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)