### PR TITLE
Baseline Skill Files & Integration

### DIFF
--- a/.claude/skills/browser-automation.md
+++ b/.claude/skills/browser-automation.md
@@ -1,0 +1,139 @@
+# Skill: Browser Automation
+
+<!-- Governing: SPEC-0023 REQ-10, REQ-11, REQ-12; ADR-0022 -->
+
+## Purpose
+
+Interact with web UIs for tasks that cannot be accomplished via APIs or CLIs. Primary use cases include credential rotation through web-based admin panels, interacting with services that only expose web interfaces, and verifying visual state of web applications. This skill requires the Chrome DevTools MCP sidecar or a Playwright-compatible environment.
+
+## Tier Requirement
+
+Tier 2 minimum. Browser automation can perform mutating actions (form submissions, credential changes). Tier 1 agents MUST NOT execute this skill and MUST escalate to Tier 2. Read-only browser inspection (taking screenshots, checking page content) is still classified as Tier 2 because it requires the browser sidecar infrastructure.
+
+## Tool Discovery
+
+This skill uses the following tools in preference order:
+1. **MCP**: `mcp__chrome-devtools__navigate_page`, `mcp__chrome-devtools__click`, `mcp__chrome-devtools__fill`, `mcp__chrome-devtools__take_screenshot`, `mcp__chrome-devtools__take_snapshot`, `mcp__chrome-devtools__evaluate_script` — check if available in tool listing
+2. **CLI**: `playwright` — check with `which npx` (run via `npx playwright`)
+
+**Note**: Browser automation requires either the Chrome sidecar container (for Chrome DevTools MCP) or a local Playwright installation. If neither is available, this skill cannot execute. Unlike other skills, there is no universal HTTP fallback — the purpose of this skill is to interact with UIs that do not have API equivalents.
+
+## Execution
+
+### Navigate to a Web Page
+
+#### Using MCP: mcp__chrome-devtools__navigate_page
+
+1. Call `mcp__chrome-devtools__navigate_page` with the target URL.
+2. Wait for the page to load.
+3. Log: `[skill:browser-automation] Using: mcp__chrome-devtools__navigate_page (MCP)`
+
+#### Using CLI: playwright
+
+1. This is a complex fallback. Create a temporary script or use Playwright's CLI:
+   ```bash
+   npx playwright open "<url>"
+   ```
+   For automated scripts, use Playwright's codegen or a pre-written script.
+2. Log: `[skill:browser-automation] Using: playwright (CLI)`
+3. Also log: `[skill:browser-automation] WARNING: Chrome DevTools MCP not available, falling back to playwright (CLI)`
+
+### Fill a Form Field
+
+#### Using MCP: mcp__chrome-devtools__fill
+
+1. Call `mcp__chrome-devtools__fill` with the selector and value.
+2. Log: `[skill:browser-automation] Using: mcp__chrome-devtools__fill (MCP)`
+
+### Click an Element
+
+#### Using MCP: mcp__chrome-devtools__click
+
+1. Call `mcp__chrome-devtools__click` with the element selector.
+2. Log: `[skill:browser-automation] Using: mcp__chrome-devtools__click (MCP)`
+
+### Fill a Complete Form
+
+#### Using MCP: mcp__chrome-devtools__fill_form
+
+1. Call `mcp__chrome-devtools__fill_form` with a mapping of selectors to values.
+2. Log: `[skill:browser-automation] Using: mcp__chrome-devtools__fill_form (MCP)`
+
+### Take a Screenshot
+
+#### Using MCP: mcp__chrome-devtools__take_screenshot
+
+1. Call `mcp__chrome-devtools__take_screenshot` to capture the current page state.
+2. Log: `[skill:browser-automation] Using: mcp__chrome-devtools__take_screenshot (MCP)`
+
+### Take a DOM Snapshot
+
+#### Using MCP: mcp__chrome-devtools__take_snapshot
+
+1. Call `mcp__chrome-devtools__take_snapshot` to get a text representation of the page DOM.
+2. Useful for reading page content without visual rendering.
+3. Log: `[skill:browser-automation] Using: mcp__chrome-devtools__take_snapshot (MCP)`
+
+### Execute JavaScript
+
+#### Using MCP: mcp__chrome-devtools__evaluate_script
+
+1. Call `mcp__chrome-devtools__evaluate_script` with the JavaScript code.
+2. Use for extracting data from the page or performing actions not easily expressed via selectors.
+3. Log: `[skill:browser-automation] Using: mcp__chrome-devtools__evaluate_script (MCP)`
+
+### Handle Dialogs (Alerts, Confirms, Prompts)
+
+#### Using MCP: mcp__chrome-devtools__handle_dialog
+
+1. Call `mcp__chrome-devtools__handle_dialog` to accept or dismiss the dialog.
+2. Log: `[skill:browser-automation] Using: mcp__chrome-devtools__handle_dialog (MCP)`
+
+### Credential Rotation Workflow
+
+This is a common multi-step workflow combining several browser actions:
+
+1. Navigate to the service's admin panel or settings page.
+2. Take a snapshot to understand the page structure.
+3. Locate the credential/API key field.
+4. Fill the new credential value.
+5. Click the save/submit button.
+6. Take a screenshot to verify the change was applied.
+7. Validate by checking for a success message in the page content.
+
+Log: `[skill:browser-automation] Credential rotation workflow using Chrome DevTools MCP`
+
+## Validation
+
+After navigating to a page:
+1. Take a snapshot or screenshot to confirm the page loaded.
+2. Check for error messages (404, 500, connection refused).
+
+After filling a form and submitting:
+1. Take a snapshot after submission.
+2. Check for success/error messages in the page content.
+3. Report the outcome.
+
+After credential rotation:
+1. Verify the new credential works by attempting to use it (e.g., API call with new key).
+2. Report success or failure.
+
+If no browser tools are available:
+1. Report: `[skill:browser-automation] ERROR: No suitable tool found for browser automation (Chrome DevTools MCP and Playwright both unavailable)`
+2. Recommend enabling the Chrome sidecar container via `docker compose --profile browser up -d`.
+
+## Scope Rules
+
+This skill MUST NOT:
+- Change passwords, secrets, or encryption keys unless explicitly instructed by a playbook
+- Navigate to or interact with services not defined in repo inventories
+- Submit forms that modify network configuration (DNS, VPN, firewall rules)
+- Download or upload files without explicit playbook authorization
+
+## Dry-Run Behavior
+
+When `CLAUDEOPS_DRY_RUN=true`:
+- MUST NOT click buttons, submit forms, or fill fields with real values.
+- MAY navigate to pages and take screenshots/snapshots (read-only observation).
+- MUST still perform tool discovery and selection.
+- Log: `[skill:browser-automation] DRY RUN: Would navigate to <url>, fill <fields>, and click <button> using <tool>`

--- a/.claude/skills/container-health.md
+++ b/.claude/skills/container-health.md
@@ -1,0 +1,99 @@
+# Skill: Container Health Inspection
+
+<!-- Governing: SPEC-0023 REQ-10, REQ-11, REQ-12; ADR-0022 -->
+
+## Purpose
+
+Inspect container state, health status, and logs on remote hosts defined in repo inventories. Use this skill during health check cycles to determine whether containers are running, healthy, and producing expected output.
+
+This is a read-only skill. It does NOT restart, start, or stop containers. For container lifecycle operations, see the `container-ops` skill.
+
+## Tier Requirement
+
+Tier 1 minimum. This skill performs only read-only inspection of container state and logs. All tiers may execute it.
+
+## Tool Discovery
+
+This skill uses the following tools in preference order:
+1. **MCP**: `mcp__docker__list_containers`, `mcp__docker__inspect_container`, `mcp__docker__get_container_logs` — check if available in tool listing
+2. **CLI**: `docker` (via SSH to remote host) — check with `which docker` or `which ssh`
+3. **Browser**: `mcp__chrome-devtools__navigate_page` — for web-based Docker UIs (Portainer, Dozzle) defined in inventory
+
+**Important**: Container inspection MUST target remote hosts defined in repo inventories. Do NOT use `docker ps` or `docker inspect` against the local Docker daemon — the local daemon is NOT the monitoring target.
+
+## Execution
+
+### Check Container State
+
+#### Using MCP: mcp__docker__list_containers
+
+1. Call `mcp__docker__list_containers` to get all containers and their states.
+2. Filter results to containers matching the service name from the inventory.
+3. Check the `State` field: `running`, `exited`, `restarting`, etc.
+4. Check the `Health` field if present: `healthy`, `unhealthy`, `starting`.
+5. Log: `[skill:container-health] Using: mcp__docker__list_containers (MCP)`
+
+#### Using CLI: docker (via SSH)
+
+1. Connect to the remote host defined in the inventory:
+   ```bash
+   ssh <user>@<host> "docker ps -a --filter name=<service> --format '{{.Names}}\t{{.Status}}\t{{.State}}'"
+   ```
+2. Parse the output to determine container state.
+3. For detailed health info:
+   ```bash
+   ssh <user>@<host> "docker inspect --format '{{.State.Status}} {{.State.Health.Status}}' <container>"
+   ```
+4. Log: `[skill:container-health] Using: docker via ssh (CLI)`
+5. If MCP was preferred but unavailable, also log: `[skill:container-health] WARNING: Docker MCP not available, falling back to docker via ssh (CLI)`
+
+#### Using Browser: mcp__chrome-devtools__navigate_page (Dozzle/Portainer)
+
+1. If the inventory defines a web UI URL for container management (e.g., Dozzle at `dozzle.stump.rocks`):
+   - Navigate to the container management page using `mcp__chrome-devtools__navigate_page`.
+   - Take a snapshot with `mcp__chrome-devtools__take_snapshot` to read container status.
+2. Log: `[skill:container-health] Using: mcp__chrome-devtools__navigate_page (MCP/Browser)`
+3. This path is a last resort when neither Docker MCP nor SSH is available.
+
+### Inspect Container Logs
+
+#### Using MCP: mcp__docker__get_container_logs
+
+1. Call `mcp__docker__get_container_logs` with the container name and a tail limit (e.g., last 50 lines).
+2. Scan logs for error patterns, crash loops, or OOM messages.
+3. Log: `[skill:container-health] Using: mcp__docker__get_container_logs (MCP)`
+
+#### Using CLI: docker logs (via SSH)
+
+1. Fetch recent logs:
+   ```bash
+   ssh <user>@<host> "docker logs --tail 50 --timestamps <container> 2>&1"
+   ```
+2. Scan output for error patterns.
+3. Log: `[skill:container-health] Using: docker logs via ssh (CLI)`
+
+### Check Container Resource Usage
+
+#### Using CLI: docker stats (via SSH)
+
+1. Get a one-shot resource snapshot:
+   ```bash
+   ssh <user>@<host> "docker stats --no-stream --format '{{.Name}}\t{{.CPUPerc}}\t{{.MemUsage}}\t{{.MemPerc}}' <container>"
+   ```
+2. Flag if memory usage exceeds 90% or CPU is sustained above 95%.
+3. Log: `[skill:container-health] Using: docker stats via ssh (CLI)`
+
+## Validation
+
+After inspecting container state:
+1. Confirm a clear status was obtained (running/stopped/unhealthy).
+2. If the container has a health check, confirm the health status was retrieved.
+3. Report results in the format: `<service>: <state> (<health>)` — e.g., `shamrock: running (healthy)`.
+
+After inspecting logs:
+1. Confirm logs were retrieved (may be empty for new containers).
+2. Report any error patterns found, or "no errors in recent logs".
+
+If inspection fails:
+1. Report: `[skill:container-health] ERROR: No suitable tool found for container inspection`
+2. Include which tools were attempted.

--- a/.claude/skills/container-ops.md
+++ b/.claude/skills/container-ops.md
@@ -1,0 +1,111 @@
+# Skill: Container Lifecycle Operations
+
+<!-- Governing: SPEC-0023 REQ-10, REQ-11, REQ-12; ADR-0022 -->
+
+## Purpose
+
+Restart, start, and stop containers on remote hosts as part of remediation workflows. Use this skill when a container is unhealthy or stopped and needs to be brought back to a healthy state. Always check the cooldown state before performing any operation.
+
+## Tier Requirement
+
+Tier 2 minimum. Container lifecycle operations modify infrastructure state. Tier 1 agents MUST NOT execute this skill and MUST escalate to Tier 2. For read-only container inspection, use the `container-health` skill instead.
+
+## Tool Discovery
+
+This skill uses the following tools in preference order:
+1. **MCP**: `mcp__docker__restart_container`, `mcp__docker__start_container`, `mcp__docker__stop_container` — check if available in tool listing
+2. **CLI**: `docker` (via SSH to remote host) — check with `which ssh`
+
+**Important**: All operations MUST target remote hosts defined in repo inventories. Do NOT operate on the local Docker daemon.
+
+## Execution
+
+### Restart Container
+
+#### Using MCP: mcp__docker__restart_container
+
+1. Read cooldown state from `$CLAUDEOPS_STATE_DIR/cooldown.json`.
+2. Check that the service has not exceeded the restart limit (max 2 restarts per 4-hour window).
+3. If within limits, call `mcp__docker__restart_container` with the container name.
+4. Update cooldown state with the restart timestamp.
+5. Log: `[skill:container-ops] Using: mcp__docker__restart_container (MCP)`
+
+#### Using CLI: docker restart (via SSH)
+
+1. Read cooldown state from `$CLAUDEOPS_STATE_DIR/cooldown.json`.
+2. Check restart limits (max 2 per 4-hour window).
+3. If within limits:
+   ```bash
+   ssh <user>@<host> "docker restart <container>"
+   ```
+4. Update cooldown state.
+5. Log: `[skill:container-ops] Using: docker restart via ssh (CLI)`
+6. If MCP was preferred but unavailable, also log: `[skill:container-ops] WARNING: Docker MCP not available, falling back to docker via ssh (CLI)`
+
+### Start Stopped Container
+
+#### Using MCP: mcp__docker__start_container
+
+1. Call `mcp__docker__start_container` with the container name.
+2. Log: `[skill:container-ops] Using: mcp__docker__start_container (MCP)`
+
+#### Using CLI: docker compose up -d (via SSH)
+
+1. If a compose file is available for the service:
+   ```bash
+   ssh <user>@<host> "cd /path/to/service && docker compose up -d <service>"
+   ```
+2. If no compose file, use direct start:
+   ```bash
+   ssh <user>@<host> "docker start <container>"
+   ```
+3. Log: `[skill:container-ops] Using: docker compose up -d via ssh (CLI)` or `[skill:container-ops] Using: docker start via ssh (CLI)`
+
+### Stop Container
+
+#### Using MCP: mcp__docker__stop_container
+
+1. Call `mcp__docker__stop_container` with the container name.
+2. Log: `[skill:container-ops] Using: mcp__docker__stop_container (MCP)`
+
+#### Using CLI: docker stop (via SSH)
+
+1. ```bash
+   ssh <user>@<host> "docker stop <container>"
+   ```
+2. Log: `[skill:container-ops] Using: docker stop via ssh (CLI)`
+
+## Validation
+
+After restarting a container:
+1. Wait 10-15 seconds for the container to stabilize.
+2. Use the `container-health` skill to verify the container is running and healthy.
+3. Report: `<service>: restarted successfully, now <state> (<health>)` or `<service>: restart failed, container is <state>`.
+
+After starting a container:
+1. Verify the container transitioned from stopped to running.
+2. Use the `container-health` skill to confirm health status.
+
+After stopping a container:
+1. Verify the container is in the stopped/exited state.
+
+## Scope Rules
+
+This skill MUST NOT:
+- Use `docker compose down` — this removes containers and may lose state
+- Use `docker rm` or `docker rm -f` — container removal requires human approval
+- Use `docker system prune` — bulk cleanup is never allowed
+- Use `docker volume rm` — persistent data deletion is never allowed
+- Operate on the local Docker daemon — only remote hosts from inventory
+- Exceed cooldown limits (max 2 restarts per service per 4-hour window)
+
+If any of these are attempted, refuse the operation and report:
+`[skill:container-ops] SCOPE VIOLATION: <action> is not permitted`
+
+## Dry-Run Behavior
+
+When `CLAUDEOPS_DRY_RUN=true`:
+- MUST NOT restart, start, or stop any containers.
+- MUST still check cooldown state and report whether the operation would be allowed.
+- MUST still perform tool discovery and selection.
+- Log: `[skill:container-ops] DRY RUN: Would restart <container> on <host> using <tool> (cooldown: <N> of 2 restarts used)`

--- a/.claude/skills/database-query.md
+++ b/.claude/skills/database-query.md
@@ -1,0 +1,116 @@
+# Skill: Database Query (Read-Only)
+
+<!-- Governing: SPEC-0023 REQ-10, REQ-11, REQ-12; ADR-0022 -->
+
+## Purpose
+
+Execute read-only database queries against PostgreSQL and MariaDB/MySQL instances defined in repo inventories. Use this skill to check database connectivity, verify schema state, inspect row counts, and diagnose database-related service issues.
+
+This skill is strictly read-only. It MUST NOT execute any data-modifying statements.
+
+## Tier Requirement
+
+Tier 1 minimum. This skill performs only read-only queries. All tiers may execute it. For database recovery operations (connection fixes, replication repair), Tier 3 is required and handled separately in playbooks.
+
+## Tool Discovery
+
+This skill uses the following tools in preference order:
+
+### For PostgreSQL
+1. **MCP**: `mcp__postgres__query` — check if available in tool listing
+2. **CLI**: `psql` — check with `which psql`
+
+### For MariaDB/MySQL
+1. **CLI**: `mysql` — check with `which mysql`
+
+### Universal fallback
+- **CLI**: `curl` to a database web UI (e.g., Adminer) if defined in inventory — unlikely but possible
+
+## Execution
+
+### PostgreSQL Queries
+
+#### Using MCP: mcp__postgres__query
+
+1. Call `mcp__postgres__query` with the SQL query string.
+2. The MCP tool handles connection details from its configuration.
+3. Log: `[skill:database-query] Using: mcp__postgres__query (MCP)`
+
+#### Using CLI: psql
+
+1. Construct the connection string from inventory variables:
+   ```bash
+   psql -h <host> -p <port> -U <user> -d <database> -c "<query>"
+   ```
+   - Host and credentials come from the repo inventory or environment variables.
+   - Use `PGPASSWORD` environment variable or `.pgpass` file for authentication.
+2. Log: `[skill:database-query] Using: psql (CLI)`
+3. If MCP was preferred but unavailable, also log: `[skill:database-query] WARNING: PostgreSQL MCP not available, falling back to psql (CLI)`
+
+### MariaDB/MySQL Queries
+
+#### Using CLI: mysql
+
+1. Construct the connection:
+   ```bash
+   mysql -h <host> -P <port> -u <user> -p"$DB_PASSWORD" <database> -e "<query>"
+   ```
+2. Log: `[skill:database-query] Using: mysql (CLI)`
+
+### Common Diagnostic Queries
+
+**Connection check (PostgreSQL)**:
+```sql
+SELECT 1 AS connection_ok;
+```
+
+**Connection check (MySQL)**:
+```sql
+SELECT 1 AS connection_ok;
+```
+
+**Active connections (PostgreSQL)**:
+```sql
+SELECT datname, count(*) FROM pg_stat_activity GROUP BY datname;
+```
+
+**Table sizes (PostgreSQL)**:
+```sql
+SELECT relname, pg_size_pretty(pg_total_relation_size(relid)) FROM pg_catalog.pg_statio_user_tables ORDER BY pg_total_relation_size(relid) DESC LIMIT 10;
+```
+
+**Replication status (PostgreSQL)**:
+```sql
+SELECT client_addr, state, sent_lsn, write_lsn, flush_lsn, replay_lsn FROM pg_stat_replication;
+```
+
+## Validation
+
+After executing a query:
+1. Confirm the query returned results (or an empty result set — which is valid).
+2. If the query was a connection check, confirm the result is `1`.
+3. Report results in a human-readable format.
+
+If the query fails:
+1. Report the error message (connection refused, authentication failed, timeout, etc.).
+2. Do NOT retry automatically — report the failure for the monitoring cycle to handle.
+
+## Scope Rules
+
+This skill MUST NOT execute any of the following SQL operations:
+- `INSERT`, `UPDATE`, `DELETE`, `UPSERT`, `MERGE`
+- `DROP`, `CREATE`, `ALTER`, `TRUNCATE`
+- `GRANT`, `REVOKE`
+- `VACUUM FULL` (standard `VACUUM` is acceptable as read-only maintenance)
+- Any statement that modifies data, schema, or permissions
+
+If a query contains any denied keyword, the agent MUST:
+1. Refuse the query.
+2. Report: `[skill:database-query] SCOPE VIOLATION: Refusing to execute <operation> — read-only queries only`
+
+## Dry-Run Behavior
+
+When `CLAUDEOPS_DRY_RUN=true`:
+- Read-only queries MAY still execute, as they do not modify state.
+- The agent SHOULD log the query it would run for transparency.
+- Log: `[skill:database-query] DRY RUN: Would execute query "<query>" on <host>:<port>/<database> using <tool>`

--- a/.claude/skills/git-pr.md
+++ b/.claude/skills/git-pr.md
@@ -1,0 +1,175 @@
+# Skill: Git Pull Request Operations
+
+<!-- Governing: SPEC-0023 REQ-10, REQ-11, REQ-12; ADR-0022 -->
+
+## Purpose
+
+Create, list, and check the status of pull requests across Git hosting providers (Gitea, GitHub). Use this skill when a remediation or configuration change needs to be proposed via PR, or when checking the status of existing PRs.
+
+## Tier Requirement
+
+Tier 2 minimum. Creating PRs modifies remote repository state. Tier 1 agents MUST NOT execute this skill and MUST escalate to Tier 2. Listing and viewing PR status is read-only but grouped here because PR creation is the primary use case.
+
+## Tool Discovery
+
+This skill uses the following tools in preference order:
+
+### For Gitea repositories
+1. **MCP**: `mcp__gitea__create_pull_request`, `mcp__gitea__list_pull_requests`, `mcp__gitea__get_pull_request_by_index` — check if available in tool listing
+2. **CLI**: `tea` — check with `which tea`
+3. **HTTP**: `curl` to Gitea API (`$GITEA_URL/api/v1/`) — universal fallback; requires `$GITEA_TOKEN`
+
+### For GitHub repositories
+1. **MCP**: `mcp__github__create_pull_request`, `mcp__github__list_pull_requests` — check if available in tool listing
+2. **CLI**: `gh` — check with `which gh`
+3. **HTTP**: `curl` to GitHub API (`https://api.github.com/`) — universal fallback; requires `$GITHUB_TOKEN`
+
+## Execution
+
+### Create Pull Request
+
+#### Using MCP: mcp__gitea__create_pull_request (Gitea)
+
+1. Check for duplicate PRs first using `mcp__gitea__list_pull_requests` with the target repo owner and name.
+2. If no duplicate exists, call `mcp__gitea__create_pull_request` with:
+   - `owner`: repository owner
+   - `repo`: repository name
+   - `title`: PR title
+   - `body`: PR description
+   - `head`: source branch
+   - `base`: target branch (usually `main`)
+3. Log: `[skill:git-pr] Using: mcp__gitea__create_pull_request (MCP)`
+
+#### Using MCP: mcp__github__create_pull_request (GitHub)
+
+1. Check for duplicate PRs first using `mcp__github__list_pull_requests`.
+2. If no duplicate exists, call `mcp__github__create_pull_request` with title, body, head, and base.
+3. Log: `[skill:git-pr] Using: mcp__github__create_pull_request (MCP)`
+
+#### Using CLI: gh (GitHub)
+
+1. Check for duplicates: `gh pr list --repo <owner>/<repo> --head <branch> --state open`
+2. If no duplicate, create the PR:
+   ```bash
+   gh pr create --repo <owner>/<repo> --title "<title>" --body "<body>" --head <branch> --base main
+   ```
+3. Log: `[skill:git-pr] Using: gh (CLI)`
+4. If MCP was preferred but unavailable, also log: `[skill:git-pr] WARNING: MCP tools not found for GitHub, falling back to gh (CLI)`
+
+#### Using CLI: tea (Gitea)
+
+1. Check for duplicates: `tea pr list --repo <owner>/<repo> --state open`
+2. If no duplicate, create the PR:
+   ```bash
+   tea pr create --repo <owner>/<repo> --title "<title>" --description "<body>" --head <branch> --base main
+   ```
+3. Log: `[skill:git-pr] Using: tea (CLI)`
+4. If MCP was preferred but unavailable, also log: `[skill:git-pr] WARNING: MCP tools not found for Gitea, falling back to tea (CLI)`
+
+#### Using HTTP: curl (Gitea)
+
+1. Check for duplicates:
+   ```bash
+   curl -s -H "Authorization: token $GITEA_TOKEN" "$GITEA_URL/api/v1/repos/<owner>/<repo>/pulls?state=open&head=<branch>"
+   ```
+2. If no duplicate, create the PR:
+   ```bash
+   curl -s -X POST \
+     -H "Authorization: token $GITEA_TOKEN" \
+     -H "Content-Type: application/json" \
+     -d '{"title":"<title>","body":"<body>","head":"<branch>","base":"main"}' \
+     "$GITEA_URL/api/v1/repos/<owner>/<repo>/pulls"
+   ```
+3. Log: `[skill:git-pr] Using: curl (HTTP)`
+4. If MCP and CLI were preferred but unavailable, also log: `[skill:git-pr] WARNING: MCP and CLI tools not found, falling back to curl (HTTP)`
+
+#### Using HTTP: curl (GitHub)
+
+1. Check for duplicates:
+   ```bash
+   curl -s -H "Authorization: token $GITHUB_TOKEN" "https://api.github.com/repos/<owner>/<repo>/pulls?state=open&head=<owner>:<branch>"
+   ```
+2. If no duplicate, create the PR:
+   ```bash
+   curl -s -X POST \
+     -H "Authorization: token $GITHUB_TOKEN" \
+     -H "Content-Type: application/json" \
+     -d '{"title":"<title>","body":"<body>","head":"<branch>","base":"main"}' \
+     "https://api.github.com/repos/<owner>/<repo>/pulls"
+   ```
+3. Log: `[skill:git-pr] Using: curl (HTTP)`
+
+### List Pull Requests
+
+#### Using MCP: mcp__gitea__list_pull_requests / mcp__github__list_pull_requests
+
+1. Call the appropriate MCP tool with owner, repo, and optional state filter.
+2. Log: `[skill:git-pr] Using: mcp__gitea__list_pull_requests (MCP)`
+
+#### Using CLI: gh / tea
+
+1. Run `gh pr list --repo <owner>/<repo>` or `tea pr list --repo <owner>/<repo>`.
+2. Log: `[skill:git-pr] Using: gh pr list (CLI)` or `[skill:git-pr] Using: tea pr list (CLI)`
+
+#### Using HTTP: curl
+
+1. GET the pulls endpoint with appropriate auth header.
+2. Log: `[skill:git-pr] Using: curl (HTTP)`
+
+### Get PR Status
+
+#### Using MCP: mcp__gitea__get_pull_request_by_index / mcp__github__get_pull_request
+
+1. Call with owner, repo, and PR number/index.
+2. Log: `[skill:git-pr] Using: mcp__gitea__get_pull_request_by_index (MCP)`
+
+#### Using CLI: gh / tea
+
+1. Run `gh pr view <number> --repo <owner>/<repo>` or `tea pr view <number> --repo <owner>/<repo>`.
+2. Log: `[skill:git-pr] Using: gh pr view (CLI)`
+
+#### Using HTTP: curl
+
+1. GET the specific pull endpoint.
+2. Log: `[skill:git-pr] Using: curl (HTTP)`
+
+## Validation
+
+After creating a PR:
+1. Confirm the response contains a PR number/URL.
+2. Verify the PR exists by listing or fetching its status.
+3. Report the PR URL in the monitoring cycle output.
+
+After listing PRs:
+1. Confirm the response is a valid list (may be empty).
+
+After getting PR status:
+1. Confirm the response contains the PR state (open, closed, merged).
+
+## Scope Rules
+
+This skill MUST NOT create PRs that modify any of the following files or resources:
+
+- **Inventory files**: `ie.yaml`, `vms.yaml`, or any file matching `**/inventory/*.yaml`
+- **Network configuration**: Caddy configs (`Caddyfile`, `caddy/*.json`), WireGuard configs (`wg*.conf`, `wireguard/`), DNS records
+- **Secrets and credentials**: `.env` files, `**/secrets/**`, `**/credentials/**`, `*.key`, `*.pem`, `*.crt`, password files
+- **Claude Ops runbook and prompts**: `CLAUDE.md`, `prompts/*.md`, `entrypoint.sh`, `checks/*.md`, `playbooks/*.md`
+- **Persistent data volumes**: anything under `/volumes/`
+
+If the agent detects that a proposed PR would modify any denied path, it MUST:
+1. Refuse the operation.
+2. Report: `[skill:git-pr] SCOPE VIOLATION: Refusing to create PR modifying <path> — matches denied pattern <rule>`
+3. Do NOT attempt to work around the restriction.
+
+### Branch Naming Convention
+
+PRs created by Claude Ops SHOULD use the branch naming pattern: `claude-ops/<type>/<name>` (e.g., `claude-ops/fix/shamrock-config`, `claude-ops/chore/update-api-key`).
+
+## Dry-Run Behavior
+
+When `CLAUDEOPS_DRY_RUN=true`:
+- MUST NOT create branches, commits, or pull requests.
+- MUST still perform tool discovery and selection.
+- MUST still check scope rules and report violations.
+- MAY list existing PRs (read-only).
+- Log: `[skill:git-pr] DRY RUN: Would create PR "<title>" on <owner>/<repo> from <head> to <base> using <tool>`

--- a/.claude/skills/http-request.md
+++ b/.claude/skills/http-request.md
@@ -1,0 +1,123 @@
+# Skill: HTTP Request
+
+<!-- Governing: SPEC-0023 REQ-10, REQ-11, REQ-12; ADR-0022 -->
+
+## Purpose
+
+Perform HTTP health checks and REST API interactions against services defined in repo inventories. Use this skill to verify that web services are responding, check HTTP status codes, inspect response headers, and interact with service APIs for monitoring and diagnostics.
+
+This is primarily a read-only skill used for health checks and API queries. Mutating HTTP operations (POST, PUT, DELETE to service APIs) are permitted at Tier 2+ for safe remediation tasks like cache clearing or API key updates.
+
+## Tier Requirement
+
+Tier 1 minimum for read-only health checks (GET requests, HEAD requests).
+Tier 2 minimum for mutating HTTP operations (POST, PUT, DELETE to service APIs).
+
+## Tool Discovery
+
+This skill uses the following tools in preference order:
+1. **Built-in**: `WebFetch` — always available in the Claude Code environment
+2. **MCP**: `mcp__fetch__fetch` — check if available in tool listing
+3. **CLI**: `curl` — check with `which curl`
+
+## Execution
+
+### HTTP Health Check (GET)
+
+#### Using Built-in: WebFetch
+
+1. Call `WebFetch` with the service URL and a prompt to extract status information.
+2. WebFetch fetches the URL and returns processed content.
+3. Check for successful response (the tool handles HTTP internally).
+4. Log: `[skill:http-request] Using: WebFetch (built-in)`
+
+**Limitations**: WebFetch processes content through an AI model and may not return raw status codes. For precise status code checking, prefer `curl`.
+
+#### Using MCP: mcp__fetch__fetch
+
+1. Call `mcp__fetch__fetch` with the URL.
+2. Check the response status code and body.
+3. Log: `[skill:http-request] Using: mcp__fetch__fetch (MCP)`
+4. If WebFetch was preferred but insufficient (need raw status codes), log: `[skill:http-request] Using: mcp__fetch__fetch (MCP) for precise status code`
+
+#### Using CLI: curl
+
+1. For a basic health check:
+   ```bash
+   curl -s -o /dev/null -w "%{http_code}" --connect-timeout 10 --max-time 30 "<url>"
+   ```
+2. For a health check with response body:
+   ```bash
+   curl -s --connect-timeout 10 --max-time 30 "<url>"
+   ```
+3. For a health check with headers:
+   ```bash
+   curl -s -I --connect-timeout 10 --max-time 30 "<url>"
+   ```
+4. Log: `[skill:http-request] Using: curl (CLI)`
+5. If WebFetch and MCP were preferred but unavailable, also log: `[skill:http-request] WARNING: WebFetch and Fetch MCP not suitable, falling back to curl (CLI)`
+
+### DNS Health Check
+
+#### Using CLI: dig / nslookup
+
+1. Resolve the hostname:
+   ```bash
+   dig +short <hostname>
+   ```
+   or:
+   ```bash
+   nslookup <hostname>
+   ```
+2. Confirm the hostname resolves to an expected IP address.
+3. Log: `[skill:http-request] Using: dig (CLI)` or `[skill:http-request] Using: nslookup (CLI)`
+
+### REST API Query (GET)
+
+#### Using CLI: curl (with authentication)
+
+1. For authenticated API requests:
+   ```bash
+   curl -s -H "Authorization: Bearer $TOKEN" --connect-timeout 10 --max-time 30 "<api_url>"
+   ```
+2. Parse the JSON response to extract relevant fields.
+3. Log: `[skill:http-request] Using: curl (CLI)`
+
+### Mutating API Request (POST/PUT/DELETE) — Tier 2+
+
+#### Using CLI: curl
+
+1. Verify the current tier is 2 or higher.
+2. Construct the appropriate request:
+   ```bash
+   curl -s -X POST -H "Content-Type: application/json" -H "Authorization: Bearer $TOKEN" \
+     -d '{"key": "value"}' "<api_url>"
+   ```
+3. Log: `[skill:http-request] Using: curl (CLI)`
+
+## Validation
+
+After a health check:
+1. Confirm an HTTP status code was obtained.
+2. Report the result: `<service> (<url>): HTTP <status_code>` — e.g., `shamrock (shamrock.stump.rocks): HTTP 200`.
+3. Flag unexpected status codes:
+   - 2xx: healthy
+   - 3xx: redirect (may be expected — e.g., 302 for auth-protected services)
+   - 4xx: client error (401/403 may be expected for authenticated endpoints)
+   - 5xx: server error (unhealthy)
+   - Connection timeout/refused: unreachable
+
+After a DNS check:
+1. Report whether the hostname resolved and to what IP.
+2. Flag if resolution failed: `<hostname>: DNS resolution failed`.
+
+After an API request:
+1. Confirm the response is valid JSON (or expected format).
+2. Report any error messages in the response body.
+
+## Dry-Run Behavior
+
+When `CLAUDEOPS_DRY_RUN=true`:
+- Read-only health checks (GET, HEAD, DNS) MAY still execute, as they do not modify state.
+- Mutating HTTP operations (POST, PUT, DELETE) MUST NOT execute.
+- Log: `[skill:http-request] DRY RUN: Would send <method> to <url> using <tool>`

--- a/.claude/skills/issue-tracking.md
+++ b/.claude/skills/issue-tracking.md
@@ -1,0 +1,148 @@
+# Skill: Issue Tracking
+
+<!-- Governing: SPEC-0023 REQ-10, REQ-11, REQ-12; ADR-0022 -->
+
+## Purpose
+
+Create, list, view, and update issues on Git hosting providers (Gitea, GitHub). Use this skill to file issues for problems that require human attention, track remediation work, or check the status of existing issues. Listing and viewing issues is available at all tiers; creating and updating issues requires Tier 2.
+
+## Tier Requirement
+
+Tier 1 minimum for listing and viewing issues (read-only).
+Tier 2 minimum for creating, commenting on, and updating issues.
+
+## Tool Discovery
+
+This skill uses the following tools in preference order:
+
+### For Gitea repositories
+1. **MCP**: `mcp__gitea__create_issue`, `mcp__gitea__list_repo_issues`, `mcp__gitea__get_issue_by_index`, `mcp__gitea__edit_issue`, `mcp__gitea__create_issue_comment` — check if available in tool listing
+2. **CLI**: `tea` — check with `which tea`
+3. **HTTP**: `curl` to Gitea API (`$GITEA_URL/api/v1/`) — requires `$GITEA_TOKEN`
+
+### For GitHub repositories
+1. **MCP**: `mcp__github__create_issue`, `mcp__github__list_issues`, `mcp__github__get_issue` — check if available in tool listing
+2. **CLI**: `gh` — check with `which gh`
+3. **HTTP**: `curl` to GitHub API (`https://api.github.com/`) — requires `$GITHUB_TOKEN`
+
+## Execution
+
+### Create Issue
+
+#### Using MCP: mcp__gitea__create_issue (Gitea)
+
+1. Call `mcp__gitea__create_issue` with:
+   - `owner`: repository owner
+   - `repo`: repository name
+   - `title`: issue title
+   - `body`: issue description with diagnostic context
+2. Optionally add labels using `mcp__gitea__add_issue_labels`.
+3. Log: `[skill:issue-tracking] Using: mcp__gitea__create_issue (MCP)`
+
+#### Using MCP: mcp__github__create_issue (GitHub)
+
+1. Call `mcp__github__create_issue` with title, body, and optional labels.
+2. Log: `[skill:issue-tracking] Using: mcp__github__create_issue (MCP)`
+
+#### Using CLI: gh (GitHub)
+
+1. ```bash
+   gh issue create --repo <owner>/<repo> --title "<title>" --body "<body>"
+   ```
+2. Optionally add labels: `--label "claude-ops,needs-attention"`
+3. Log: `[skill:issue-tracking] Using: gh issue create (CLI)`
+4. If MCP was preferred but unavailable, also log: `[skill:issue-tracking] WARNING: GitHub MCP not available, falling back to gh (CLI)`
+
+#### Using CLI: tea (Gitea)
+
+1. ```bash
+   tea issue create --repo <owner>/<repo> --title "<title>" --description "<body>"
+   ```
+2. Log: `[skill:issue-tracking] Using: tea issue create (CLI)`
+3. If MCP was preferred but unavailable, also log: `[skill:issue-tracking] WARNING: Gitea MCP not available, falling back to tea (CLI)`
+
+#### Using HTTP: curl (Gitea)
+
+1. ```bash
+   curl -s -X POST \
+     -H "Authorization: token $GITEA_TOKEN" \
+     -H "Content-Type: application/json" \
+     -d '{"title":"<title>","body":"<body>"}' \
+     "$GITEA_URL/api/v1/repos/<owner>/<repo>/issues"
+   ```
+2. Log: `[skill:issue-tracking] Using: curl (HTTP)`
+3. If MCP and CLI were preferred but unavailable, also log: `[skill:issue-tracking] WARNING: MCP and CLI not available, falling back to curl (HTTP)`
+
+#### Using HTTP: curl (GitHub)
+
+1. ```bash
+   curl -s -X POST \
+     -H "Authorization: token $GITHUB_TOKEN" \
+     -H "Content-Type: application/json" \
+     -d '{"title":"<title>","body":"<body>"}' \
+     "https://api.github.com/repos/<owner>/<repo>/issues"
+   ```
+2. Log: `[skill:issue-tracking] Using: curl (HTTP)`
+
+### List Issues
+
+#### Using MCP: mcp__gitea__list_repo_issues / mcp__github__list_issues
+
+1. Call the appropriate MCP tool with owner, repo, and optional state filter.
+2. Log: `[skill:issue-tracking] Using: mcp__gitea__list_repo_issues (MCP)` or `[skill:issue-tracking] Using: mcp__github__list_issues (MCP)`
+
+#### Using CLI: gh / tea
+
+1. `gh issue list --repo <owner>/<repo>` or `tea issue list --repo <owner>/<repo>`.
+2. Log: `[skill:issue-tracking] Using: gh issue list (CLI)` or `[skill:issue-tracking] Using: tea issue list (CLI)`
+
+#### Using HTTP: curl
+
+1. GET the issues endpoint with appropriate auth header.
+2. Log: `[skill:issue-tracking] Using: curl (HTTP)`
+
+### View Issue
+
+#### Using MCP: mcp__gitea__get_issue_by_index / mcp__github__get_issue
+
+1. Call with owner, repo, and issue number.
+2. Log: `[skill:issue-tracking] Using: mcp__gitea__get_issue_by_index (MCP)`
+
+#### Using CLI: gh / tea
+
+1. `gh issue view <number> --repo <owner>/<repo>` or `tea issue view <number> --repo <owner>/<repo>`.
+2. Log: `[skill:issue-tracking] Using: gh issue view (CLI)`
+
+### Add Comment to Issue
+
+#### Using MCP: mcp__gitea__create_issue_comment
+
+1. Call with owner, repo, issue index, and comment body.
+2. Log: `[skill:issue-tracking] Using: mcp__gitea__create_issue_comment (MCP)`
+
+#### Using CLI: gh
+
+1. ```bash
+   gh issue comment <number> --repo <owner>/<repo> --body "<comment>"
+   ```
+2. Log: `[skill:issue-tracking] Using: gh issue comment (CLI)`
+
+## Validation
+
+After creating an issue:
+1. Confirm the response contains an issue number/URL.
+2. Report the issue URL in the monitoring cycle output.
+
+After listing issues:
+1. Confirm a valid list was returned (may be empty).
+
+After viewing an issue:
+1. Confirm the issue details were retrieved (title, state, body).
+
+## Dry-Run Behavior
+
+When `CLAUDEOPS_DRY_RUN=true`:
+- MUST NOT create, update, or comment on issues.
+- MAY list and view existing issues (read-only).
+- MUST still perform tool discovery and selection.
+- Log: `[skill:issue-tracking] DRY RUN: Would create issue "<title>" on <owner>/<repo> using <tool>`


### PR DESCRIPTION
## Summary

Adds 7 baseline skill files covering all 6 required domains from SPEC-0023 REQ-10:

| Skill File | Domain | Tier | Tool Paths |
|---|---|---|---|
| `git-pr.md` | Git operations | Tier 2 | Gitea MCP, GitHub MCP, `gh`, `tea`, `curl` |
| `container-health.md` | Container ops (read) | Tier 1 | Docker MCP, `docker` via SSH, Chrome DevTools |
| `container-ops.md` | Container ops (write) | Tier 2 | Docker MCP, `docker` via SSH |
| `database-query.md` | Database (read-only) | Tier 1 | PostgreSQL MCP, `psql`, `mysql` |
| `http-request.md` | HTTP operations | Tier 1 | WebFetch, Fetch MCP, `curl` |
| `issue-tracking.md` | Issue tracking | Tier 2 | Gitea MCP, GitHub MCP, `gh`, `tea`, `curl` |
| `browser-automation.md` | Browser automation | Tier 2 | Chrome DevTools MCP, Playwright |

Each skill follows the SPEC-0023 REQ-1 format:
- Title, Purpose, Tier Requirement, Tool Discovery, Execution (per tool path), Validation
- Mutating skills include Scope Rules and Dry-Run Behavior sections
- Fallback observability log lines per REQ-5 convention
- `git-pr.md` includes comprehensive scope rules preserving denied paths from `ValidateScope()`

## Governing

- SPEC-0023 REQ-10 (Skill Domains), REQ-11 (Composability), REQ-12 (Testability)
- ADR-0022: Skills-Based Tool Orchestration

## Test Plan

- [ ] Verify all 7 files exist in `.claude/skills/`
- [ ] Each file has required sections: Title, Purpose, Tier Requirement, Tool Discovery, Execution, Validation
- [ ] `git-pr.md` scope rules include: `ie.yaml`, `vms.yaml`, network configs, secrets, Claude Ops prompts
- [ ] Mutating skills (`git-pr`, `container-ops`, `database-query`, `issue-tracking`, `browser-automation`) have Dry-Run sections
- [ ] Each execution section has sub-sections per tool path with observability log lines

Closes #382
Part of #378