### PR TITLE
Permission & Safety Controls

### DIFF
--- a/prompts/tier1-observe.md
+++ b/prompts/tier1-observe.md
@@ -12,6 +12,29 @@ Use these paths (hardcoded defaults — do NOT rely on environment variable expa
 
 **IMPORTANT**: Always use literal paths (`/repos`, `/state`, `/results`) in your bash commands — never `"$CLAUDEOPS_REPOS_DIR"` or similar variable expansions. The env vars may not be set in all environments, causing empty-string expansion and silent failures.
 
+## Tier Permission
+
+Your tier is `$CLAUDEOPS_TIER` (Tier 1 = Observe, Tier 2 = Safe Remediation, Tier 3 = Full Remediation).
+
+When loading a skill:
+1. Read the skill's "Tier Requirement" section
+2. If your tier is below the minimum, MUST NOT execute — escalate to the appropriate tier instead
+3. If `CLAUDEOPS_TIER` is not set, treat yourself as Tier 1
+
+Your tier is: **Tier 1**
+
+Governing: SPEC-0023 REQ-6, ADR-0023
+
+## Dry-Run Mode
+
+When `CLAUDEOPS_DRY_RUN=true`:
+- MUST NOT execute any mutating operations (container restarts, PR creation, file modifications, notifications)
+- For each mutating action, log: `[dry-run] Would: <action> using <tool> with <parameters>`
+- Read-only operations (health checks, listing resources, status queries) MAY still execute
+- Scope violations MUST still be detected and reported even in dry-run mode
+
+Governing: SPEC-0023 REQ-7
+
 ## Step 1: Discover Infrastructure Repos
 
 Scan `/repos` for mounted repositories:

--- a/prompts/tier2-investigate.md
+++ b/prompts/tier2-investigate.md
@@ -21,6 +21,45 @@ You must NOT:
 - Recreate containers from scratch
 - Anything in the "Never Allowed" list in CLAUDE.md
 
+## Tier Permission
+
+Your tier is `$CLAUDEOPS_TIER` (Tier 1 = Observe, Tier 2 = Safe Remediation, Tier 3 = Full Remediation).
+
+When loading a skill:
+1. Read the skill's "Tier Requirement" section
+2. If your tier is below the minimum, MUST NOT execute — escalate to the appropriate tier instead
+3. If `CLAUDEOPS_TIER` is not set, treat yourself as Tier 1
+
+Your tier is: **Tier 2**
+
+Governing: SPEC-0023 REQ-6, ADR-0023
+
+## Dry-Run Mode
+
+When `CLAUDEOPS_DRY_RUN=true`:
+- MUST NOT execute any mutating operations (container restarts, PR creation, file modifications, notifications)
+- For each mutating action, log: `[dry-run] Would: <action> using <tool> with <parameters>`
+- Read-only operations (health checks, listing resources, status queries) MAY still execute
+- Scope violations MUST still be detected and reported even in dry-run mode
+
+Governing: SPEC-0023 REQ-7
+
+## Scope Enforcement
+
+Before any mutating operation, check the relevant skill's "Scope Rules" section.
+
+MUST NOT modify:
+- Inventory files: `ie.yaml`, `vms.yaml`, or any host inventory file
+- Network configuration: Caddy config, WireGuard config, DNS records
+- Secrets and credentials (passwords, API keys, tokens)
+- Claude Ops runbook and prompt files (`prompts/`, `CLAUDE.md`, `entrypoint.sh`)
+- Docker volumes under `/volumes/`
+
+If an operation would violate a scope rule, MUST refuse and report:
+`[scope-violation] Refused: <operation> would modify <path>, which is denied by scope rule: <rule>`
+
+Governing: SPEC-0023 REQ-8, ADR-0022
+
 ## Step 1: Review Context
 
 Read the failure summary provided by Tier 1. For each failed service, note:

--- a/prompts/tier3-remediate.md
+++ b/prompts/tier3-remediate.md
@@ -23,6 +23,45 @@ You must NOT:
 - Modify inventory, playbooks, charts, or Dockerfiles
 - Change passwords, secrets, or encryption keys
 
+## Tier Permission
+
+Your tier is `$CLAUDEOPS_TIER` (Tier 1 = Observe, Tier 2 = Safe Remediation, Tier 3 = Full Remediation).
+
+When loading a skill:
+1. Read the skill's "Tier Requirement" section
+2. If your tier is below the minimum, MUST NOT execute — escalate to the appropriate tier instead
+3. If `CLAUDEOPS_TIER` is not set, treat yourself as Tier 1
+
+Your tier is: **Tier 3**
+
+Governing: SPEC-0023 REQ-6, ADR-0023
+
+## Dry-Run Mode
+
+When `CLAUDEOPS_DRY_RUN=true`:
+- MUST NOT execute any mutating operations (container restarts, PR creation, file modifications, notifications)
+- For each mutating action, log: `[dry-run] Would: <action> using <tool> with <parameters>`
+- Read-only operations (health checks, listing resources, status queries) MAY still execute
+- Scope violations MUST still be detected and reported even in dry-run mode
+
+Governing: SPEC-0023 REQ-7
+
+## Scope Enforcement
+
+Before any mutating operation, check the relevant skill's "Scope Rules" section.
+
+MUST NOT modify:
+- Inventory files: `ie.yaml`, `vms.yaml`, or any host inventory file
+- Network configuration: Caddy config, WireGuard config, DNS records
+- Secrets and credentials (passwords, API keys, tokens)
+- Claude Ops runbook and prompt files (`prompts/`, `CLAUDE.md`, `entrypoint.sh`)
+- Docker volumes under `/volumes/`
+
+If an operation would violate a scope rule, MUST refuse and report:
+`[scope-violation] Refused: <operation> would modify <path>, which is denied by scope rule: <rule>`
+
+Governing: SPEC-0023 REQ-8, ADR-0022
+
 ## Step 1: Review Context
 
 Read the investigation findings from Tier 2:


### PR DESCRIPTION
## Summary

- Add `--disallowedTools` flag to `entrypoint.sh` with a default Tier 1 blocklist that prevents mutating operations (docker restart/stop/start, ansible, git push, apprise, etc.)
- Add `CLAUDEOPS_TIER` environment variable (default: 1) passed through `ENV_CONTEXT` so agents can read their own tier
- Add **Tier Permission** section to all 3 tier prompts for tier-aware skill loading with escalation
- Add **Dry-Run Mode** section to all 3 tier prompts (`[dry-run] Would:` logging for mutating actions)
- Add **Scope Enforcement** section to Tier 2 and Tier 3 prompts with deny list for inventory files, network config, secrets, volumes, and runbook files

## Test plan

- [ ] Verify `entrypoint.sh` passes `--disallowedTools` to the `claude` CLI invocation
- [ ] Verify `CLAUDEOPS_TIER` defaults to 1 and is included in `ENV_CONTEXT`
- [ ] Verify `CLAUDEOPS_DISALLOWED_TOOLS` env var overrides the default blocklist
- [ ] Verify tier1 prompt has Tier Permission and Dry-Run sections but NOT Scope Enforcement
- [ ] Verify tier2 and tier3 prompts have Tier Permission, Dry-Run, AND Scope Enforcement sections
- [ ] Run `make test` and `make build` to ensure no regressions

Closes #381
Part of #378

Governing: SPEC-0023 REQ-6 REQ-7 REQ-8 / ADR-0022 ADR-0023

🤖 Generated with [Claude Code](https://claude.com/claude-code)