### PR TITLE
Add SPEC-0001 governing comments to tier 2 and tier 3 prompts

### DIFF
--- a/prompts/tier2-investigate.md
+++ b/prompts/tier2-investigate.md
@@ -1,3 +1,5 @@
+<!-- Governing: SPEC-0001 REQ-4 — Tier 2 Safe Remediation Permissions -->
+
 # Tier 2: Investigate and Remediate
 
 You are Claude Ops, escalated from a Tier 1 health check. Services have been identified as unhealthy. Your job is to investigate the root cause and apply safe remediations.

--- a/prompts/tier3-remediate.md
+++ b/prompts/tier3-remediate.md
@@ -1,3 +1,5 @@
+<!-- Governing: SPEC-0001 REQ-5 — Tier 3 Full Remediation Permissions -->
+
 # Tier 3: Full Remediation
 
 You are Claude Ops at the highest escalation tier. Sonnet investigated and attempted safe remediations, but the issue persists. You have full remediation capabilities.


### PR DESCRIPTION
## Summary

- Adds `<!-- Governing: SPEC-0001 REQ-4 -->` to `prompts/tier2-investigate.md`
- Adds `<!-- Governing: SPEC-0001 REQ-5 -->` to `prompts/tier3-remediate.md`
- Both files already satisfy SPEC-0001 requirements; this adds traceability comments

Both prompt files were audited against SPEC-0001 REQ-4 (Tier 2 Safe Remediation Permissions) and REQ-5 (Tier 3 Full Remediation Permissions). The existing content already satisfies all specification requirements:

**REQ-4 (Tier 2)**: Inherits Tier 1 permissions, permits docker restart/compose up, file permission fixes, tmp/cache clearing, API key updates via REST, browser automation, Apprise notifications. Prohibits Ansible, Helm, container recreation. Escalates to Tier 3 with full findings when unable to resolve.

**REQ-5 (Tier 3)**: Inherits Tier 1+2 permissions, permits Ansible playbooks, Helm upgrades, container recreation, DB connectivity fixes, multi-service orchestrated recovery. Sends "NEEDS HUMAN ATTENTION" via Apprise with root cause, attempted actions, and next steps when unable to fix. Prohibits Never-Allowed actions.

Closes #285
Part of epic #1
Part of SPEC-0001

## Test plan

- [x] Verify `tier2-investigate.md` contains governing comment for SPEC-0001 REQ-4
- [x] Verify `tier3-remediate.md` contains governing comment for SPEC-0001 REQ-5
- [x] Verify existing permission sections match SPEC-0001 requirements
- [x] Verify escalation behavior (Tier 2 → Tier 3) is documented
- [x] Verify "NEEDS HUMAN ATTENTION" notification is documented in Tier 3

🤖 Generated with [Claude Code](https://claude.com/claude-code)