### PR TITLE
Add SPEC-0001 REQ-9/REQ-11 compliance to tier prompt files

### DIFF
--- a/prompts/tier1-observe.md
+++ b/prompts/tier1-observe.md
@@ -1,4 +1,5 @@
 <!-- Governing: SPEC-0002 REQ-4 (Tier Prompt Document Structure) -->
+<!-- Governing: SPEC-0001 REQ-9, REQ-11 -->
 
 # Tier 1: Observe
 
@@ -91,6 +92,22 @@ When loading a skill:
 Your tier is: **Tier 1**
 
 Governing: SPEC-0003 REQ-6, SPEC-0003 REQ-7, SPEC-0023 REQ-6, ADR-0023
+
+## Never Allowed (Any Tier)
+
+These actions MUST NEVER be performed, regardless of tier. They always require human intervention:
+
+- Delete persistent data volumes
+- Modify inventory files, playbooks, Helm charts, or Dockerfiles
+- Change passwords, secrets, or encryption keys
+- Modify network configuration (VPN, WireGuard, Caddy, DNS records)
+- `docker system prune` or any bulk cleanup
+- Push to git repositories
+- Any action on hosts not listed in the inventory
+- Any action on services not defined in a mounted repo's inventory
+- Discover or inspect services via `docker ps`, process lists, or network scanning — only repo-defined services exist
+- Drop or truncate database tables
+- Modify the runbook or any prompt files
 
 <!-- Governing: SPEC-0018 REQ-12 "Dry Run Mode" — PR creation included in mutating operations denied during dry run -->
 ## Dry-Run Mode

--- a/prompts/tier2-investigate.md
+++ b/prompts/tier2-investigate.md
@@ -1,5 +1,6 @@
 <!-- Governing: SPEC-0001 REQ-4, SPEC-0002 REQ-4 (Tier Prompt Document Structure) -->
 <!-- Governing: SPEC-0003 REQ-8 (Subagent Tier Isolation) -->
+<!-- Governing: SPEC-0001 REQ-4 — Tier 2 Safe Remediation Permissions, REQ-9, REQ-11 -->
 # Tier 2: Investigate and Remediate
 
 <!-- Governing: SPEC-0001 REQ-8 (Permission-Model Alignment) — Tier 2 permits safe remediation only; Ansible/Helm/container recreation prohibited -->

--- a/prompts/tier3-remediate.md
+++ b/prompts/tier3-remediate.md
@@ -1,5 +1,6 @@
 <!-- Governing: SPEC-0001 REQ-5, SPEC-0002 REQ-4 (Tier Prompt Document Structure) -->
 <!-- Governing: SPEC-0003 REQ-8 (Subagent Tier Isolation) -->
+<!-- Governing: SPEC-0001 REQ-5 — Tier 3 Full Remediation Permissions, REQ-9, REQ-11 -->
 # Tier 3: Full Remediation
 
 <!-- Governing: SPEC-0001 REQ-8 (Permission-Model Alignment) — Tier 3 permits all remediations except Never-Allowed actions -->


### PR DESCRIPTION
## Summary

- Adds an explicit **Never Allowed (Any Tier)** section to `prompts/tier1-observe.md`, which was the only tier prompt missing this list. Tier 2 and Tier 3 already reference the list via CLAUDE.md.
- Adds `<!-- Governing: SPEC-0001 REQ-9, REQ-11 -->` comments to all three tier prompt files for design traceability.

Closes #287
Part of epic #1
Part of SPEC-0001

## Test plan

- [ ] Verify `prompts/tier1-observe.md` contains the "Never Allowed (Any Tier)" section with all 10 prohibited actions from REQ-11
- [ ] Verify `prompts/tier2-investigate.md` references the Never Allowed list (via CLAUDE.md) and has the governing comment
- [ ] Verify `prompts/tier3-remediate.md` references the Never Allowed list (via CLAUDE.md) and has the governing comment
- [ ] Verify no remediation procedures are included in `tier1-observe.md` (REQ-9)
- [ ] Verify `tier2-investigate.md` instructs: review Tier 1 context, investigate, safe remediation, escalate to Tier 3 (REQ-9)
- [ ] Verify `tier3-remediate.md` instructs: review Tier 2 context, full remediation, report outcomes (REQ-9)

🤖 Generated with [Claude Code](https://claude.com/claude-code)