### PR TITLE
Add escalation context forwarding and governing comments (SPEC-0001)

### DIFF
--- a/prompts/tier3-remediate.md
+++ b/prompts/tier3-remediate.md
@@ -2,10 +2,13 @@
 
 # Tier 3: Full Remediation
 
+<!-- Governing: SPEC-0001 REQ-8 (Permission-Model Alignment) — Tier 3 permits all remediations except Never-Allowed actions -->
+
 You are Claude Ops at the highest escalation tier. Sonnet investigated and attempted safe remediations, but the issue persists. You have full remediation capabilities.
 
 **This is the terminal tier — there is no further escalation.** If you cannot fix the issue, send an Apprise notification requesting human attention.
 
+<!-- Governing: SPEC-0001 REQ-6 (Escalation Context Forwarding) — Do NOT re-run checks or re-attempt failed remediations from prior tiers -->
 You will receive investigation findings from Tier 2 via your system prompt (injected from the handoff file by the Go supervisor). Do NOT re-run basic checks or re-attempt remediations that already failed.
 
 ## Skill Discovery
@@ -166,10 +169,14 @@ Governing: SPEC-0023 REQ-8, ADR-0022
 
 ## Step 1: Review Context
 
-Read the investigation findings from Tier 2:
-- Original failure (from Tier 1)
-- Root cause analysis (from Tier 2)
-- What was attempted and why it failed
+<!-- Governing: SPEC-0001 REQ-6 (Escalation Context Forwarding) -->
+
+Read the investigation findings from Tier 2. The handoff context includes:
+- Original failure summary (service names, check results, error messages from Tier 1)
+- Root cause analysis and investigation findings (from Tier 2)
+- Remediation actions attempted and their outcomes (from Tier 2)
+- Current cooldown state
+- SSH host access map
 
 <!-- Governing: SPEC-0020 "Tier Integration" — Tier 3 reuses the SSH access map from handoff -->
 Read the **SSH host access map** from the handoff file. The map tells you which user and method (`root`, `sudo`, `limited`, `unreachable`) to use for each host. If the handoff includes an `ssh_access_map` field, use it directly — do NOT re-probe SSH access. If the map is missing, read `/app/skills/ssh-discovery.md` and run the discovery routine before proceeding.


### PR DESCRIPTION
## Summary

- Adds `<!-- Governing: SPEC-0001 REQ-6, REQ-7, REQ-8 -->` comments to all three tier prompts for traceability between implementation and spec
- Expands handoff JSON schemas to include `cooldown_state` (Tier 1) and `ssh_access_map` + `cooldown_state` (Tier 2) so all accumulated context is forwarded during escalation
- Expands "Review Context" sections in Tier 2 and Tier 3 prompts to explicitly enumerate all expected handoff fields
- Adds explicit "MUST NOT attempt remediation" and "MUST NOT re-run checks" instructions to reinforce permission boundaries

## Test plan

- [ ] Verify Tier 1 prompt includes REQ-8 governing comment at top and REQ-6/7/8 in Step 6
- [ ] Verify Tier 1 handoff JSON schema includes `cooldown_state` field
- [ ] Verify Tier 2 prompt includes REQ-8 and REQ-6 governing comments
- [ ] Verify Tier 2 handoff JSON schema includes `ssh_access_map` and `cooldown_state`
- [ ] Verify Tier 2 "Step 1: Review Context" lists all expected handoff fields
- [ ] Verify Tier 3 prompt includes REQ-8 and REQ-6 governing comments
- [ ] Verify Tier 3 "Step 1: Review Context" lists all expected handoff fields
- [ ] Run `/design:check` to verify spec alignment

Closes #286
Part of epic #1
Part of SPEC-0001

🤖 Generated with [Claude Code](https://claude.com/claude-code)