### PR TITLE
Add SPEC-0002 governing comments for markdown format compliance

### DIFF
--- a/checks/containers.md
+++ b/checks/containers.md
@@ -1,3 +1,5 @@
+<!-- Governing: SPEC-0002 REQ-1 (markdown as sole instruction format), REQ-8 (no build step), REQ-9 (self-documenting) -->
+
 # Container State Checks
 
 ## When to Run

--- a/checks/databases.md
+++ b/checks/databases.md
@@ -1,3 +1,5 @@
+<!-- Governing: SPEC-0002 REQ-1 (markdown as sole instruction format), REQ-8 (no build step), REQ-9 (self-documenting) -->
+
 # Database Health Checks
 
 ## PostgreSQL

--- a/checks/dns.md
+++ b/checks/dns.md
@@ -1,3 +1,5 @@
+<!-- Governing: SPEC-0002 REQ-1 (markdown as sole instruction format), REQ-8 (no build step), REQ-9 (self-documenting) -->
+
 # DNS Verification
 
 ## When to Run

--- a/checks/http.md
+++ b/checks/http.md
@@ -1,3 +1,5 @@
+<!-- Governing: SPEC-0002 REQ-1 (markdown as sole instruction format), REQ-8 (no build step), REQ-9 (self-documenting) -->
+
 # HTTP Health Checks
 
 ## When to Run

--- a/checks/services.md
+++ b/checks/services.md
@@ -1,3 +1,5 @@
+<!-- Governing: SPEC-0002 REQ-1 (markdown as sole instruction format), REQ-8 (no build step), REQ-9 (self-documenting) -->
+
 # Service-Specific Checks
 
 These are checks for specific applications that go beyond basic HTTP/container health. Claude should identify which of these apply based on the services discovered in the inventory.

--- a/playbooks/redeploy-service.md
+++ b/playbooks/redeploy-service.md
@@ -1,3 +1,5 @@
+<!-- Governing: SPEC-0002 REQ-1 (markdown as sole instruction format), REQ-8 (no build step), REQ-9 (self-documenting) -->
+
 # Playbook: Redeploy Service
 
 **Tier**: 3 (Opus) only

--- a/playbooks/restart-container.md
+++ b/playbooks/restart-container.md
@@ -1,3 +1,5 @@
+<!-- Governing: SPEC-0002 REQ-1 (markdown as sole instruction format), REQ-8 (no build step), REQ-9 (self-documenting) -->
+
 # Playbook: Restart Container
 
 **Tier**: 2 (Sonnet) minimum

--- a/playbooks/rotate-api-key.md
+++ b/playbooks/rotate-api-key.md
@@ -1,3 +1,5 @@
+<!-- Governing: SPEC-0002 REQ-1 (markdown as sole instruction format), REQ-8 (no build step), REQ-9 (self-documenting) -->
+
 # Playbook: Rotate API Key
 
 **Tier**: 2 (Sonnet) minimum


### PR DESCRIPTION
Closes #288
Part of epic #95
Part of SPEC-0002

## Summary

- Added `<!-- Governing: SPEC-0002 REQ-1, REQ-8, REQ-9 -->` comments to all 5 check files (`checks/http.md`, `checks/dns.md`, `checks/containers.md`, `checks/databases.md`, `checks/services.md`) and all 3 playbook files (`playbooks/restart-container.md`, `playbooks/redeploy-service.md`, `playbooks/rotate-api-key.md`)
- Verified that all operational instruction files are pure markdown with no binary formats, JSON schemas, or YAML configs for instructions (REQ-1)
- Verified that no build step, compilation, or schema validation is required to add or modify checks/playbooks (REQ-8)
- Verified that each instruction document is human-readable and self-documenting without tooling (REQ-9)

## Test plan

- [ ] Verify governing comments are present at the top of each modified file
- [ ] Confirm no non-markdown instruction formats exist in `checks/` or `playbooks/`
- [ ] Validate that adding a new `.md` file to `checks/` requires no additional steps

🤖 Generated with [Claude Code](https://claude.com/claude-code)