### PR TITLE
Repo Extensions & Tier Gating (SPEC-0002 REQ-7/11)

### DIFF
--- a/playbooks/redeploy-service.md
+++ b/playbooks/redeploy-service.md
@@ -2,6 +2,8 @@
 
 # Playbook: Redeploy Service
 
+<!-- Governing: SPEC-0002 REQ-11 — Playbook Tier Gating, REQ-3 — Playbook Document Structure -->
+
 **Tier**: 3 (Opus) only
 
 ## When to Use

--- a/playbooks/restart-container.md
+++ b/playbooks/restart-container.md
@@ -2,6 +2,8 @@
 
 # Playbook: Restart Container
 
+<!-- Governing: SPEC-0002 REQ-11 — Playbook Tier Gating, REQ-3 — Playbook Document Structure -->
+
 **Tier**: 2 (Sonnet) minimum
 
 ## When to Use

--- a/playbooks/rotate-api-key.md
+++ b/playbooks/rotate-api-key.md
@@ -2,6 +2,8 @@
 
 # Playbook: Rotate API Key
 
+<!-- Governing: SPEC-0002 REQ-11 — Playbook Tier Gating, REQ-3 — Playbook Document Structure -->
+
 **Tier**: 2 (Sonnet) minimum
 
 ## When to Use

--- a/prompts/tier1-observe.md
+++ b/prompts/tier1-observe.md
@@ -151,6 +151,7 @@ These log lines MUST appear in the output whenever a skill is invoked so that to
 ## Step 1: Discover Infrastructure Repos
 
 <!-- Governing: SPEC-0005 REQ-1 (Repo Discovery via Directory Scanning) -->
+<!-- Governing: SPEC-0002 REQ-7 — Repo-Specific Extensions via Markdown -->
 
 Scan `/repos` for mounted repositories. This scan MUST be performed every cycle so that newly mounted or removed repos are detected without requiring a container restart.
 
@@ -257,7 +258,11 @@ Run checks ONLY against the hosts and services discovered from repos. **Never ch
 - Check for service-specific health indicators (see `/app/checks/services.md`)
 
 ### Repo-Specific Checks
+
+<!-- Governing: SPEC-0002 REQ-7 — Repo-Specific Extensions via Markdown -->
+
 - For each mounted repo with `.claude-ops/checks/`, read and execute those checks
+- These extensions MUST follow the same format requirements as built-in checks (see REQ-2)
 - These are additional checks defined by the repo owner for their specific services
 - Run them after the standard checks above
 

--- a/prompts/tier3-remediate.md
+++ b/prompts/tier3-remediate.md
@@ -26,6 +26,28 @@ Before starting remediation, discover and load available skills:
 
 Re-discovery happens each monitoring cycle. Do not cache skill lists across runs.
 
+## Repo Extension Discovery
+
+<!-- Governing: SPEC-0002 REQ-7 — Repo-Specific Extensions via Markdown -->
+
+In addition to skill discovery (above), discover repo-specific checks and playbooks:
+
+1. **Repo checks**: For each mounted repo under `/repos/`, check for `.claude-ops/checks/` and read any `.md` files found there. These extend the built-in checks and follow the same format requirements.
+2. **Repo playbooks**: For each mounted repo under `/repos/`, check for `.claude-ops/playbooks/` and read any `.md` files found there. These are remediation procedures specific to the repo's services. They follow the same format as built-in playbooks and MUST specify a minimum tier.
+
+## Playbook Tier Gating
+
+<!-- Governing: SPEC-0002 REQ-11 — Playbook Tier Gating -->
+
+Before executing any playbook (built-in or repo-contributed):
+
+1. Read the playbook's **Tier** line (e.g., `**Tier**: 2 (Sonnet) minimum` or `**Tier**: 3 (Opus) only`)
+2. If your tier is **below** the playbook's minimum, MUST NOT execute the playbook — this situation should not occur at Tier 3 since it is the highest tier
+3. If your tier is **equal to or above** the playbook's minimum, you MAY execute the playbook (the minimum is a floor, not a ceiling)
+4. If a playbook does not specify a tier, treat it as requiring Tier 3 (safest default)
+
+Your tier is: **Tier 3**. You may execute all playbooks regardless of their minimum tier.
+
 ## Session Initialization: Tool Inventory
 
 <!-- Governing: SPEC-0023 REQ-3, REQ-4, REQ-5 / ADR-0022 -->
@@ -223,8 +245,9 @@ Do NOT probe for or use alternative remote access methods (Docker TCP API on por
 ## Step 4: Remediate
 
 <!-- Governing: SPEC-0002 REQ-10 — Agent Reads Checks at Runtime -->
+<!-- Governing: SPEC-0002 REQ-11 — Playbook Tier Gating -->
 
-Read the applicable playbook files from `/app/playbooks/` and `.claude-ops/playbooks/` from mounted repos at runtime. Do NOT rely on cached or pre-compiled instructions — always re-read playbook files before executing them.
+Read the applicable playbook files from `/app/playbooks/` and `.claude-ops/playbooks/` from mounted repos at runtime. Do NOT rely on cached or pre-compiled instructions — always re-read playbook files before executing them. **Before executing any playbook, check its minimum tier requirement.** As Tier 3, you may execute all playbooks regardless of their minimum tier.
 
 ### Ansible redeployment
 1. Identify the correct playbook and inventory from the mounted repo


### PR DESCRIPTION
Closes #291
Part of epic #95
Part of SPEC-0002

## Summary

- Adds `<!-- Governing: SPEC-0002 REQ-7 -->` comments to repo extension discovery sections in `tier1-observe.md`
- Adds explicit **Repo Extension Discovery** sections to `tier2-investigate.md` and `tier3-remediate.md` instructing agents to discover `.claude-ops/checks/` and `.claude-ops/playbooks/` from mounted repos (not just skills)
- Adds explicit **Playbook Tier Gating** sections to `tier2-investigate.md` and `tier3-remediate.md` with step-by-step tier-check instructions before executing any playbook
- Adds `<!-- Governing: SPEC-0002 REQ-11 -->` comments to all three playbook files and remediation steps in tier prompts
- References repo-contributed playbooks in investigation and remediation steps

## Test plan

- [ ] Verify `go vet ./...` passes (confirmed locally)
- [ ] Verify `go test ./... -count=1 -race` passes (confirmed locally)
- [ ] Review that tier1 prompt discovers `.claude-ops/checks/` from repos
- [ ] Review that tier2/tier3 prompts discover `.claude-ops/checks/` and `.claude-ops/playbooks/` from repos
- [ ] Review that tier2 prompt enforces playbook tier gating (rejects Tier 3 playbooks)
- [ ] Review that tier3 prompt documents it can execute all playbooks
- [ ] Review governing comments on all playbook files

🤖 Generated with [Claude Code](https://claude.com/claude-code)