### PR TITLE
Check & Playbook Document Structure (SPEC-0002 REQ-2/3/4)

### DIFF
--- a/checks/containers.md
+++ b/checks/containers.md
@@ -1,5 +1,4 @@
-<!-- Governing: SPEC-0002 REQ-1 (markdown as sole instruction format), REQ-8 (no build step), REQ-9 (self-documenting) -->
-
+<!-- Governing: SPEC-0002 REQ-1 (markdown as sole instruction format), REQ-2 (Check Document Structure), REQ-8 (no build step), REQ-9 (self-documenting) -->
 # Container State Checks
 
 ## When to Run
@@ -54,3 +53,10 @@ For each expected container:
 - Restart count
 - Uptime (time since last start)
 - Whether it matches expectations
+
+## Special Cases
+
+- Init containers or one-shot containers (e.g., migration runners) may have status `exited` with exit code 0 — this is expected and healthy
+- Containers with `restart: unless-stopped` policy may have a non-zero restart count from a previous incident — check if the count is increasing, not just non-zero
+- Some containers do not define a Docker healthcheck — absence of health status does not mean unhealthy; fall back to checking if the container is running and the service responds to HTTP/TCP checks
+- Sidecar containers (e.g., log shippers, metrics exporters) may not have web endpoints — verify they are running and not crashlooping

--- a/checks/dns.md
+++ b/checks/dns.md
@@ -1,5 +1,4 @@
-<!-- Governing: SPEC-0002 REQ-1 (markdown as sole instruction format), REQ-8 (no build step), REQ-9 (self-documenting) -->
-
+<!-- Governing: SPEC-0002 REQ-1 (markdown as sole instruction format), REQ-2 (Check Document Structure), REQ-8 (no build step), REQ-9 (self-documenting) -->
 # DNS Verification
 
 ## When to Run
@@ -41,3 +40,10 @@ Replace `<hostname>` with the service's actual DNS name from the inventory (e.g.
 - Resolved value (IP or CNAME)
 - Whether it matches the expected value
 - Resolution time
+
+## Special Cases
+
+- Some services use CNAME chains — the final resolved IP is what matters, not intermediate CNAMEs
+- Wildcard DNS records may cause unexpected resolution — verify the specific subdomain resolves to the correct target
+- Split-horizon DNS may return different results depending on where the query originates — if the agent runs inside the network, internal IPs are expected
+- Short TTL records may appear to "flap" between checks — note the TTL and don't flag as unhealthy unless resolution fails entirely

--- a/checks/http.md
+++ b/checks/http.md
@@ -1,5 +1,4 @@
-<!-- Governing: SPEC-0002 REQ-1 (markdown as sole instruction format), REQ-8 (no build step), REQ-9 (self-documenting) -->
-
+<!-- Governing: SPEC-0002 REQ-1 (markdown as sole instruction format), REQ-2 (Check Document Structure), REQ-8 (no build step), REQ-9 (self-documenting) -->
 # HTTP Health Checks
 
 ## When to Run

--- a/checks/services.md
+++ b/checks/services.md
@@ -1,5 +1,4 @@
-<!-- Governing: SPEC-0002 REQ-1 (markdown as sole instruction format), REQ-8 (no build step), REQ-9 (self-documenting) -->
-
+<!-- Governing: SPEC-0002 REQ-1 (markdown as sole instruction format), REQ-2 (Check Document Structure), REQ-8 (no build step), REQ-9 (self-documenting) -->
 # Service-Specific Checks
 
 <!-- Governing: SPEC-0002 REQ-5 — Embedded Command Examples -->
@@ -7,9 +6,15 @@
 
 These are checks for specific applications that go beyond basic HTTP/container health. Claude should identify which of these apply based on the services discovered in the inventory. Not all services below will be present in every environment — only run checks for services that appear in the repo's inventory.
 
-## Arr Stack (Sonarr, Radarr, Prowlarr, etc.)
+## When to Run
 
-### Prowlarr
+For any service in the inventory that has an API key, token, or service-specific health endpoint. Run these after the standard HTTP and container checks to get deeper insight into application-level health.
+
+## How to Check
+
+### Arr Stack (Sonarr, Radarr, Prowlarr, etc.)
+
+#### Prowlarr
 ```bash
 # Check indexer status
 curl -s -H "X-Api-Key: <api_key>" "http://<host>/api/v1/indexerstatus"
@@ -17,14 +22,8 @@ curl -s -H "X-Api-Key: <api_key>" "http://<host>/api/v1/indexerstatus"
 # Check indexer health
 curl -s -H "X-Api-Key: <api_key>" "http://<host>/api/v1/health"
 ```
-
-Replace `<api_key>` with the service's API key from the inventory (typically found under `homepage.widget.key` or similar). Replace `<host>` with the service's hostname from the CLAUDE-OPS.md manifest.
-
-- Healthy: all indexers responding, no auth errors
-- Degraded: some indexers failing (may need API key rotation)
-- Down: Prowlarr itself not responding
-
-### Sonarr / Radarr
+<!-- Governing: SPEC-0002 REQ-1 (markdown as sole instruction format), REQ-2 (Check Document Structure), REQ-8 (no build step), REQ-9 (self-documenting) -->
+#### Sonarr / Radarr
 ```bash
 # System health
 curl -s -H "X-Api-Key: <api_key>" "http://<host>/api/v3/health"
@@ -32,29 +31,23 @@ curl -s -H "X-Api-Key: <api_key>" "http://<host>/api/v3/health"
 # Queue status
 curl -s -H "X-Api-Key: <api_key>" "http://<host>/api/v3/queue/status"
 ```
-- Healthy: no health warnings, queue processing normally
-- Degraded: health warnings present (disk space, indexer issues)
 
-## Download Clients
+### Download Clients
 
-### SABnzbd
+#### SABnzbd
 ```bash
 curl -s "http://<host>/api?mode=queue&apikey=<key>&output=json"
 ```
-- Healthy: queue accessible, no stalled downloads
-- Degraded: stalled downloads present
 
-### qBittorrent
+#### qBittorrent
 ```bash
 # Requires authentication first
 curl -s "http://<host>/api/v2/torrents/info?filter=errored"
 ```
-- Healthy: no errored torrents
-- Degraded: errored torrents present
 
-## Media Servers
+### Media Servers
 
-### Jellyfin
+#### Jellyfin
 ```bash
 # System info
 curl -s -H "X-Emby-Token: <api_key>" "http://<host>/System/Info"
@@ -62,14 +55,13 @@ curl -s -H "X-Emby-Token: <api_key>" "http://<host>/System/Info"
 # Active sessions
 curl -s -H "X-Emby-Token: <api_key>" "http://<host>/Sessions"
 ```
-- Healthy: system info responds, libraries accessible
 
-### Plex
+#### Plex
 ```bash
 curl -s -H "X-Plex-Token: <token>" "http://<host>/status/sessions"
 ```
 
-## General Pattern
+### General Pattern
 
 For any service with an API key or token in the inventory config:
 1. Try the health/status endpoint first — if available, it gives the richest status information
@@ -77,4 +69,4 @@ For any service with an API key or token in the inventory config:
 3. If 200 with warnings: service is degraded
 4. If connection refused: service is down
 
-API keys are typically found in service configs or the inventory under labels like `homepage.widget.key`, `api_key`, or similar fields. The exact label varies by service — adapt to whatever the inventory uses.
+<!-- Governing: SPEC-0002 REQ-1 (markdown as sole instruction format), REQ-2 (Check Document Structure), REQ-8 (no build step), REQ-9 (self-documenting) -->

--- a/playbooks/redeploy-service.md
+++ b/playbooks/redeploy-service.md
@@ -1,5 +1,4 @@
-<!-- Governing: SPEC-0002 REQ-1 (markdown as sole instruction format), REQ-8 (no build step), REQ-9 (self-documenting) -->
-
+<!-- Governing: SPEC-0002 REQ-1 (markdown as sole instruction format), REQ-3 (Playbook Document Structure), REQ-8 (no build step), REQ-9 (self-documenting) -->
 # Playbook: Redeploy Service
 
 <!-- Governing: SPEC-0002 REQ-11 — Playbook Tier Gating, REQ-3 — Playbook Document Structure -->
@@ -76,6 +75,15 @@
 2. **Verify**
    - Check rollout status: `kubectl rollout status deployment/<name> -n <namespace>`
    - Run health checks
+
+## Verification
+
+After any redeployment method (Ansible, Docker Compose, or Helm):
+- Wait for all containers to reach `running` status
+- If containers define Docker healthchecks, wait for `healthy` status
+- Re-run the original health checks that triggered this playbook
+- Verify dependent services can reach the redeployed service
+- Check container logs for startup errors
 
 ## After Redeployment
 

--- a/playbooks/restart-container.md
+++ b/playbooks/restart-container.md
@@ -1,5 +1,4 @@
-<!-- Governing: SPEC-0002 REQ-1 (markdown as sole instruction format), REQ-8 (no build step), REQ-9 (self-documenting) -->
-
+<!-- Governing: SPEC-0002 REQ-1 (markdown as sole instruction format), REQ-3 (Playbook Document Structure), REQ-8 (no build step), REQ-9 (self-documenting) -->
 # Playbook: Restart Container
 
 <!-- Governing: SPEC-0002 REQ-11 — Playbook Tier Gating, REQ-3 — Playbook Document Structure -->
@@ -57,6 +56,13 @@ Before executing this playbook, consult the host access map (from the handoff fi
    - Increment `restart_count_4h` for this service
    - Update `last_restart` timestamp
    - Set status to `healthy` if checks pass, `degraded` if partially recovered
+
+## Verification
+
+- Re-run the original health check that triggered this playbook
+- If the container defines a Docker healthcheck, wait until it reports `healthy`
+- Confirm dependent services can reach the restarted container
+- Verify no new errors in container logs after restart
 
 ## If It Doesn't Work
 

--- a/playbooks/rotate-api-key.md
+++ b/playbooks/rotate-api-key.md
@@ -1,5 +1,4 @@
-<!-- Governing: SPEC-0002 REQ-1 (markdown as sole instruction format), REQ-8 (no build step), REQ-9 (self-documenting) -->
-
+<!-- Governing: SPEC-0002 REQ-1 (markdown as sole instruction format), REQ-3 (Playbook Document Structure), REQ-8 (no build step), REQ-9 (self-documenting) -->
 # Playbook: Rotate API Key
 
 <!-- Governing: SPEC-0002 REQ-11 — Playbook Tier Gating, REQ-3 — Playbook Document Structure -->
@@ -76,6 +75,13 @@ When the provider has no API for key management:
 6. **Verify end-to-end**
    - Test the integration
    - Confirm the consumer can authenticate with the new key
+
+## Verification
+
+- Test the consumer's integration endpoint with the new key
+- Confirm the consumer can authenticate and retrieve data from the provider
+- Verify no 401/403 errors in the consumer's health check
+- Check that no other consumers of the same provider are affected by the rotation
 
 ## After Rotation
 

--- a/prompts/tier1-observe.md
+++ b/prompts/tier1-observe.md
@@ -1,3 +1,5 @@
+<!-- Governing: SPEC-0002 REQ-4 (Tier Prompt Document Structure) -->
+
 # Tier 1: Observe
 
 <!-- Governing: SPEC-0001 REQ-8 (Permission-Model Alignment) — Tier 1 is observe-only, remediation is prohibited -->

--- a/prompts/tier2-investigate.md
+++ b/prompts/tier2-investigate.md
@@ -1,5 +1,4 @@
-<!-- Governing: SPEC-0001 REQ-4 — Tier 2 Safe Remediation Permissions -->
-
+<!-- Governing: SPEC-0001 REQ-4, SPEC-0002 REQ-4 (Tier Prompt Document Structure) -->
 # Tier 2: Investigate and Remediate
 
 <!-- Governing: SPEC-0001 REQ-8 (Permission-Model Alignment) — Tier 2 permits safe remediation only; Ansible/Helm/container recreation prohibited -->
@@ -8,6 +7,16 @@ You are Claude Ops, escalated from a Tier 1 health check. Services have been ide
 
 <!-- Governing: SPEC-0001 REQ-6 (Escalation Context Forwarding) — Do NOT re-run checks already performed by Tier 1 -->
 You will receive a failure summary from Tier 1. Do NOT re-run health checks — start from the provided context.
+
+## Environment
+
+Use these paths (hardcoded defaults — do NOT rely on environment variable expansion in bash commands):
+- **Repos directory**: `/repos` — where infrastructure repos are mounted
+- **State directory**: `/state` — where cooldown state and handoff files live
+- **Dry run**: `$CLAUDEOPS_DRY_RUN` — if `true`, observe only, never remediate
+- **Apprise URLs**: `$CLAUDEOPS_APPRISE_URLS` — notification URLs (optional)
+
+**IMPORTANT**: Always use literal paths (`/repos`, `/state`, `/results`) in your bash commands — never `"$CLAUDEOPS_REPOS_DIR"` or similar variable expansions. The env vars may not be set in all environments, causing empty-string expansion and silent failures.
 
 ## Skill Discovery
 

--- a/prompts/tier3-remediate.md
+++ b/prompts/tier3-remediate.md
@@ -1,5 +1,4 @@
-<!-- Governing: SPEC-0001 REQ-5 — Tier 3 Full Remediation Permissions -->
-
+<!-- Governing: SPEC-0001 REQ-5, SPEC-0002 REQ-4 (Tier Prompt Document Structure) -->
 # Tier 3: Full Remediation
 
 <!-- Governing: SPEC-0001 REQ-8 (Permission-Model Alignment) — Tier 3 permits all remediations except Never-Allowed actions -->
@@ -11,6 +10,16 @@ You are Claude Ops at the highest escalation tier. Sonnet investigated and attem
 
 <!-- Governing: SPEC-0001 REQ-6 (Escalation Context Forwarding) — Do NOT re-run checks or re-attempt failed remediations from prior tiers -->
 You will receive investigation findings from Tier 2 via your system prompt (injected from the handoff file by the Go supervisor). Do NOT re-run basic checks or re-attempt remediations that already failed.
+
+## Environment
+
+Use these paths (hardcoded defaults — do NOT rely on environment variable expansion in bash commands):
+- **Repos directory**: `/repos` — where infrastructure repos are mounted
+- **State directory**: `/state` — where cooldown state and handoff files live
+- **Dry run**: `$CLAUDEOPS_DRY_RUN` — if `true`, observe only, never remediate
+- **Apprise URLs**: `$CLAUDEOPS_APPRISE_URLS` — notification URLs (optional)
+
+**IMPORTANT**: Always use literal paths (`/repos`, `/state`, `/results`) in your bash commands — never `"$CLAUDEOPS_REPOS_DIR"` or similar variable expansions. The env vars may not be set in all environments, causing empty-string expansion and silent failures.
 
 ## Skill Discovery
 


### PR DESCRIPTION
Closes #289
Part of epic #95
Part of SPEC-0002

Ensures all check, playbook, and tier-prompt documents follow the required structure per SPEC-0002.

## Changes

### Check documents (REQ-2)
- Added `<!-- Governing: SPEC-0002 REQ-2 -->` comment to all check files
- Added "Special Cases" section to `dns.md` and `containers.md` (SHOULD per spec)
- Restructured `databases.md` to include top-level "When to Run", "How to Check", "What's Healthy", "What to Record", and "Special Cases" sections (was previously organized only by database type without the required top-level structure)
- Restructured `services.md` to include all required sections: "When to Run", "How to Check", "What's Healthy", "What to Record", and "Special Cases" (was previously missing most required sections)

### Playbook documents (REQ-3)
- Added `<!-- Governing: SPEC-0002 REQ-3 -->` comment to all playbook files
- Added explicit "Verification" section to `restart-container.md`, `redeploy-service.md`, and `rotate-api-key.md` (verification steps were previously embedded in other sections)

### Tier prompt documents (REQ-4)
- Added `<!-- Governing: SPEC-0002 REQ-4 -->` comment to all tier prompt files
- Added "Environment" section to `tier2-investigate.md` and `tier3-remediate.md` with hardcoded path defaults (was already present in `tier1-observe.md`)