### PR TITLE
Add SPEC-0003 governing comments for tool and prompt enforcement

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -8,9 +8,12 @@ MODEL="${CLAUDEOPS_TIER1_MODEL:-haiku}"
 STATE_DIR="${CLAUDEOPS_STATE_DIR:-/state}"
 RESULTS_DIR="${CLAUDEOPS_RESULTS_DIR:-/results}"
 REPOS_DIR="${CLAUDEOPS_REPOS_DIR:-/repos}"
-# Governing: SPEC-0010 REQ-5 "Tool filtering via --allowedTools"
+# Governing: SPEC-0003 REQ-6 (Tool-Level Enforcement via --allowedTools),
+#            SPEC-0003 REQ-11 (Permission Modification Without Rebuild),
+#            SPEC-0010 REQ-5 "Tool filtering via --allowedTools",
+#            ADR-0023 (AllowedTools-Based Tier Enforcement)
 # — restricts available tools at the CLI runtime level, providing defense-in-depth
-# for the permission tier model. Tier 1 default: read-only tools.
+# for the permission tier model. Configurable via env var — changes take effect on next container restart (REQ-11).
 ALLOWED_TOOLS="${CLAUDEOPS_ALLOWED_TOOLS:-Bash,Read,Grep,Glob,Task,WebFetch}"
 # Governing: ADR-0023 (AllowedTools-Based Tier Enforcement), SPEC-0010 REQ-5
 # Default to Tier 1 blocklist (most restrictive)
@@ -96,7 +99,9 @@ while true; do
         ENV_CONTEXT="${ENV_CONTEXT} CLAUDEOPS_APPRISE_URLS=${CLAUDEOPS_APPRISE_URLS}"
     fi
 
-    # Governing: SPEC-0010 REQ-2 (Subprocess Invocation from Bash — CLI flags for all config, non-interactive, piped output)
+    # Governing: SPEC-0003 REQ-6 (--allowedTools hard boundary),
+    #            SPEC-0003 REQ-11 (prompt read at runtime — changes take effect next cycle),
+    #            SPEC-0010 REQ-2 (Subprocess Invocation from Bash — CLI flags for all config, non-interactive, piped output)
     # Run Claude with tier 1 prompt
     # Governing: SPEC-0010 REQ-5 — --allowedTools and --disallowedTools enforce
     # tool filtering at CLI runtime, independent of prompt-level instructions.

--- a/prompts/tier1-observe.md
+++ b/prompts/tier1-observe.md
@@ -69,6 +69,8 @@ These actions ALWAYS require a human. Never do any of these:
 
 ## Tier Permission
 
+<!-- Governing: SPEC-0003 REQ-7 (Prompt-Level Permission Enforcement) -->
+
 Your tier is `$CLAUDEOPS_TIER` (Tier 1 = Observe, Tier 2 = Safe Remediation, Tier 3 = Full Remediation).
 
 When loading a skill:
@@ -78,7 +80,7 @@ When loading a skill:
 
 Your tier is: **Tier 1**
 
-Governing: SPEC-0023 REQ-6, ADR-0023
+Governing: SPEC-0003 REQ-6, SPEC-0003 REQ-7, SPEC-0023 REQ-6, ADR-0023
 
 <!-- Governing: SPEC-0018 REQ-12 "Dry Run Mode" — PR creation included in mutating operations denied during dry run -->
 ## Dry-Run Mode

--- a/prompts/tier2-investigate.md
+++ b/prompts/tier2-investigate.md
@@ -24,6 +24,7 @@ Re-discovery happens each monitoring cycle. Do not cache skill lists across runs
 
 <!-- Governing: SPEC-0003 REQ-1 — Three-Tier Permission Hierarchy -->
 <!-- Governing: SPEC-0003 REQ-3 — Tier 2 Permitted Operations -->
+<!-- Governing: SPEC-0003 REQ-7 (Prompt-Level Permission Enforcement) -->
 
 Your tier is: **Tier 2 (Safe Remediation)**
 
@@ -74,7 +75,7 @@ When loading a skill:
 
 Your tier is: **Tier 2**
 
-Governing: SPEC-0023 REQ-6, ADR-0023
+Governing: SPEC-0003 REQ-6, SPEC-0003 REQ-7, SPEC-0023 REQ-6, ADR-0023
 
 <!-- Governing: SPEC-0018 REQ-12 "Dry Run Mode" — PR creation included in mutating operations denied during dry run -->
 ## Dry-Run Mode

--- a/prompts/tier3-remediate.md
+++ b/prompts/tier3-remediate.md
@@ -81,6 +81,7 @@ These log lines MUST appear in the output whenever a skill is invoked so that to
 
 <!-- Governing: SPEC-0003 REQ-1 — Three-Tier Permission Hierarchy -->
 <!-- Governing: SPEC-0003 REQ-4 — Tier 3 Permitted Operations -->
+<!-- Governing: SPEC-0003 REQ-7 (Prompt-Level Permission Enforcement) -->
 
 Your tier is: **Tier 3 (Full Remediation)**
 
@@ -135,7 +136,7 @@ When loading a skill:
 
 Your tier is: **Tier 3**
 
-Governing: SPEC-0023 REQ-6, ADR-0023
+Governing: SPEC-0003 REQ-6, SPEC-0003 REQ-7, SPEC-0023 REQ-6, ADR-0023
 
 <!-- Governing: SPEC-0018 REQ-12 "Dry Run Mode" — PR creation included in mutating operations denied during dry run -->
 ## Dry-Run Mode


### PR DESCRIPTION
Closes #294
Part of epic #198
Part of SPEC-0003

## Summary

- Added governing comments tracing the existing implementation back to SPEC-0003 REQ-6 (Tool-Level Enforcement via --allowedTools), REQ-7 (Prompt-Level Permission Enforcement), and REQ-11 (Permission Modification Without Rebuild)
- `entrypoint.sh`: annotated `CLAUDEOPS_ALLOWED_TOOLS` / `CLAUDEOPS_DISALLOWED_TOOLS` env vars and the `claude` CLI invocation with `--allowedTools` / `--disallowedTools` flags
- `prompts/tier1-observe.md`, `tier2-investigate.md`, `tier3-remediate.md`: annotated "Your Permissions" and "Tier Permission" sections with SPEC-0003 REQ-7 governing comments
- All three requirements were already fully implemented; this PR adds traceability

## Test plan

- [ ] Verify `entrypoint.sh` still uses `--allowedTools` and `--disallowedTools` flags correctly
- [ ] Verify each tier prompt has a "Your Permissions" section with explicit may/must-not lists
- [ ] Verify `CLAUDEOPS_ALLOWED_TOOLS` env var is configurable without container rebuild
- [ ] Confirm governing comments reference SPEC-0003 REQ-6, REQ-7, REQ-11

🤖 Generated with [Claude Code](https://claude.com/claude-code)