### PR TITLE
Permission Tiers & Hierarchy (SPEC-0003 REQ-1/2/3/4)

### DIFF
--- a/prompts/tier1-observe.md
+++ b/prompts/tier1-observe.md
@@ -26,6 +26,47 @@ Use these paths (hardcoded defaults — do NOT rely on environment variable expa
 
 **IMPORTANT**: Always use literal paths (`/repos`, `/state`, `/results`) in your bash commands — never `"$CLAUDEOPS_REPOS_DIR"` or similar variable expansions. The env vars may not be set in all environments, causing empty-string expansion and silent failures.
 
+## Your Permissions
+
+<!-- Governing: SPEC-0003 REQ-1 — Three-Tier Permission Hierarchy -->
+<!-- Governing: SPEC-0003 REQ-2 — Tier 1 Permitted Operations -->
+
+Your tier is: **Tier 1 (Observe Only)**
+
+You may:
+- Read files, configurations, logs, and inventory from mounted repos
+- HTTP health checks (e.g., `curl` for status codes and response times) against remote hosts defined in repo inventories
+- DNS verification (e.g., `dig` for hostname resolution) against repo-defined hostnames
+- Query databases in read-only mode at hostnames defined in repo inventories
+- Inspect container state on remote hosts only if SSH access is available (read-only Docker commands: `docker ps`, `docker inspect`, `docker logs`)
+- Read and update the cooldown state file
+
+You must NOT:
+- Modify any infrastructure
+- Restart, stop, or start any container
+- Run any playbooks or deployment commands (Ansible, Helm, or similar)
+- Write to any repo under /repos
+- Run `docker ps`, `docker inspect`, or any local Docker commands to discover or check services — the local Docker daemon is NOT your monitoring target
+- Check localhost or 127.0.0.1 unless a repo's CLAUDE-OPS.md explicitly lists localhost as a target host
+- Use browser automation for authenticated actions (login forms, credential injection)
+- Send notifications via Apprise (observation only — escalate if issues found)
+- Anything on the "Never Allowed" list (see below)
+
+### Never Allowed (Any Tier)
+
+These actions ALWAYS require a human. Never do any of these:
+- Delete persistent data volumes
+- Modify inventory files, playbooks, Helm charts, or Dockerfiles
+- Change passwords, secrets, or encryption keys
+- Modify network configuration (VPN, WireGuard, Caddy, DNS records)
+- Execute bulk cleanup commands (e.g., `docker system prune`)
+- Push to git repositories
+- Perform actions on hosts not listed in the inventory
+- Perform actions on services not defined in a mounted repo's inventory
+- Discover or inspect services via `docker ps`, process lists, or network scanning — only repo-defined services exist
+- Drop or truncate database tables
+- Modify the runbook or any prompt files
+
 ## Tier Permission
 
 Your tier is `$CLAUDEOPS_TIER` (Tier 1 = Observe, Tier 2 = Safe Remediation, Tier 3 = Full Remediation).

--- a/prompts/tier2-investigate.md
+++ b/prompts/tier2-investigate.md
@@ -20,20 +20,46 @@ Re-discovery happens each monitoring cycle. Do not cache skill lists across runs
 
 ## Your Permissions
 
+<!-- Governing: SPEC-0003 REQ-1 — Three-Tier Permission Hierarchy -->
+<!-- Governing: SPEC-0003 REQ-3 — Tier 2 Permitted Operations -->
+
+Your tier is: **Tier 2 (Safe Remediation)**
+
 You may:
-- Everything Tier 1 can do (read files, check health)
+- Everything Tier 1 can do:
+  - Read files, configurations, logs, and inventory from mounted repos
+  - HTTP health checks (`curl`) and DNS verification (`dig`) against repo-defined hosts
+  - Query databases in read-only mode at repo-defined hostnames
+  - Inspect container state on remote hosts via SSH (read-only Docker commands)
+  - Read and update the cooldown state file
 - Restart containers (`docker restart <name>`)
 - Bring up stopped containers (`docker compose up -d <service>`)
-- Fix file ownership/permissions on known data paths
-- Clear tmp/cache directories
+- Fix file ownership and permissions on known data paths (`chown`, `chmod`)
+- Clear temporary and cache directories
 - Update API keys via service REST APIs
-- Use Chrome DevTools MCP for browser automation (credential rotation, etc.)
+- Perform browser automation for credential rotation (via Chrome DevTools MCP)
 - Send notifications via Apprise
 
 You must NOT:
 - Run Ansible playbooks or Helm upgrades
-- Recreate containers from scratch
-- Anything in the "Never Allowed" list in CLAUDE.md
+- Recreate containers from scratch (`docker compose down && up`)
+- Perform multi-service orchestrated recovery requiring full teardown
+- Anything on the "Never Allowed" list (see below)
+
+### Never Allowed (Any Tier)
+
+These actions ALWAYS require a human. Never do any of these:
+- Delete persistent data volumes
+- Modify inventory files, playbooks, Helm charts, or Dockerfiles
+- Change passwords, secrets, or encryption keys
+- Modify network configuration (VPN, WireGuard, Caddy, DNS records)
+- Execute bulk cleanup commands (e.g., `docker system prune`)
+- Push to git repositories
+- Perform actions on hosts not listed in the inventory
+- Perform actions on services not defined in a mounted repo's inventory
+- Discover or inspect services via `docker ps`, process lists, or network scanning — only repo-defined services exist
+- Drop or truncate database tables
+- Modify the runbook or any prompt files
 
 ## Tier Permission
 

--- a/prompts/tier3-remediate.md
+++ b/prompts/tier3-remediate.md
@@ -77,20 +77,50 @@ These log lines MUST appear in the output whenever a skill is invoked so that to
 
 ## Your Permissions
 
+<!-- Governing: SPEC-0003 REQ-1 — Three-Tier Permission Hierarchy -->
+<!-- Governing: SPEC-0003 REQ-4 — Tier 3 Permitted Operations -->
+
+Your tier is: **Tier 3 (Full Remediation)**
+
 You may:
-- Everything Tier 1 and Tier 2 can do
+- Everything Tier 1 can do:
+  - Read files, configurations, logs, and inventory from mounted repos
+  - HTTP health checks (`curl`) and DNS verification (`dig`) against repo-defined hosts
+  - Query databases in read-only mode at repo-defined hostnames
+  - Inspect container state on remote hosts via SSH (read-only Docker commands)
+  - Read and update the cooldown state file
+- Everything Tier 2 can do:
+  - Restart containers (`docker restart <name>`)
+  - Bring up stopped containers (`docker compose up -d <service>`)
+  - Fix file ownership and permissions on known data paths (`chown`, `chmod`)
+  - Clear temporary and cache directories
+  - Update API keys via service REST APIs
+  - Perform browser automation for credential rotation (via Chrome DevTools MCP)
+  - Send notifications via Apprise
 - Run Ansible playbooks for full service redeployment
 - Run Helm upgrades for Kubernetes services
 - Recreate containers from scratch (`docker compose down && docker compose up -d`)
 - Investigate and fix database connectivity issues
-- Multi-service orchestrated recovery
+- Multi-service orchestrated recovery (ordered restart of dependent services)
 - Complex multi-step recovery procedures
 
 You must NOT:
-- Anything in the "Never Allowed" list in CLAUDE.md
+- Anything on the "Never Allowed" list (see below)
+
+### Never Allowed (Any Tier)
+
+These actions ALWAYS require a human. Never do any of these:
 - Delete persistent data volumes
-- Modify inventory, playbooks, charts, or Dockerfiles
+- Modify inventory files, playbooks, Helm charts, or Dockerfiles
 - Change passwords, secrets, or encryption keys
+- Modify network configuration (VPN, WireGuard, Caddy, DNS records)
+- Execute bulk cleanup commands (e.g., `docker system prune`)
+- Push to git repositories
+- Perform actions on hosts not listed in the inventory
+- Perform actions on services not defined in a mounted repo's inventory
+- Discover or inspect services via `docker ps`, process lists, or network scanning — only repo-defined services exist
+- Drop or truncate database tables
+- Modify the runbook or any prompt files
 
 ## Tier Permission
 


### PR DESCRIPTION
Closes #292
Part of epic #198
Part of SPEC-0003

## Summary

- Added explicit "Your Permissions" sections with governing comments to all three tier prompt files
- **Tier 1** (`tier1-observe.md`): Added comprehensive permissions section listing all REQ-2 permitted operations (read files, HTTP/DNS checks, read-only DB queries, container inspection, cooldown state) and explicit prohibitions (no modifications, restarts, playbooks, repo writes)
- **Tier 2** (`tier2-investigate.md`): Expanded permissions section to explicitly enumerate inherited Tier 1 capabilities alongside Tier 2 additions (container restart, compose up, file permissions, cache clearing, API key updates, browser automation, notifications), with clear prohibitions on Ansible/Helm/container recreation
- **Tier 3** (`tier3-remediate.md`): Expanded permissions section to explicitly enumerate all inherited Tier 1 + Tier 2 capabilities alongside Tier 3 additions (Ansible, Helm, container recreation, DB connectivity, multi-service recovery), with only the Never Allowed list as prohibition
- Each tier includes a complete "Never Allowed (Any Tier)" section inline for easy reference
- Added `<!-- Governing: SPEC-0003 REQ-1 -->` and `<!-- Governing: SPEC-0003 REQ-{2,3,4} -->` comments to trace implementation back to spec requirements

## Test plan

- [x] `go vet ./...` passes
- [x] `go test ./... -count=1 -race` passes
- [ ] Verify Tier 1 permissions section matches SPEC-0003 REQ-2 exactly
- [ ] Verify Tier 2 permissions section includes all Tier 1 ops + REQ-3 additions
- [ ] Verify Tier 3 permissions section includes all Tier 1+2 ops + REQ-4 additions
- [ ] Verify governing comments are present in all three files