### PR TITLE
Never-Allowed Actions & Safety Posture (SPEC-0003 REQ-5/12)

### DIFF
--- a/prompts/tier1-observe.md
+++ b/prompts/tier1-observe.md
@@ -7,6 +7,9 @@
 
 You are Claude Ops running a scheduled health check. Your job is to discover services and check their health. You do NOT remediate — if something is broken, you escalate. This tier is designed to run on the cheapest available model (Haiku by default) so that routine healthy cycles incur minimal cost. Only when issues are detected should higher-tier (and more expensive) models be invoked.
 
+<!-- Governing: SPEC-0003 REQ-5 — Never Allowed reference -->
+You must NOT do anything in the "Never Allowed" list in CLAUDE.md. Those operations are prohibited at ALL tiers, including Tier 3.
+
 ## Step 0: Skill Discovery
 
 <!-- Governing: SPEC-0023 REQ-2 — Skill Discovery and Loading -->

--- a/prompts/tier2-investigate.md
+++ b/prompts/tier2-investigate.md
@@ -32,6 +32,7 @@ Before starting investigation, discover and load available skills:
 
 Re-discovery happens each monitoring cycle. Do not cache skill lists across runs.
 
+<!-- Governing: SPEC-0003 REQ-5 — Never Allowed reference -->
 ## Your Permissions
 
 <!-- Governing: SPEC-0003 REQ-1 — Three-Tier Permission Hierarchy -->

--- a/prompts/tier3-remediate.md
+++ b/prompts/tier3-remediate.md
@@ -112,6 +112,7 @@ When executing a skill, log the tool selection outcome using these conventions:
 
 These log lines MUST appear in the output whenever a skill is invoked so that tool selection decisions are traceable.
 
+<!-- Governing: SPEC-0003 REQ-5 — Never Allowed reference -->
 ## Your Permissions
 
 <!-- Governing: SPEC-0003 REQ-1 — Three-Tier Permission Hierarchy -->


### PR DESCRIPTION
Closes #293
Part of epic #198
Part of SPEC-0003

## Summary

- Adds `<!-- Governing: SPEC-0003 REQ-5 -->` comment to the existing "Never Allowed (Any Tier)" section in CLAUDE.md, which already contains all 9+ prohibited operations from REQ-5.
- Adds explicit Never Allowed reference to `prompts/tier1-observe.md` (tier2 and tier3 already had this reference).
- Adds governing comments (`<!-- Governing: SPEC-0003 REQ-5 — Never Allowed reference -->`) to all three tier prompt files.
- Adds a new "Enforcement Model and Limitations" section to CLAUDE.md (REQ-12) that honestly acknowledges: prompt enforcement relies on model compliance, `--allowedTools` is tool-level only, no runtime interception exists, and violations are detectable post-hoc. Recommends Docker-level hardening as complementary defense-in-depth.

## Test plan

- [x] `go vet ./...` passes
- [x] `go test ./... -count=1 -race` passes
- [ ] Review that CLAUDE.md "Never Allowed" section covers all REQ-5 items
- [ ] Review that all 3 tier prompts reference the Never Allowed list
- [ ] Review that REQ-12 safety posture acknowledgment is accurate and complete