### PR TITLE
Auditability & Post-Hoc Review (SPEC-0003 REQ-10)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -97,7 +97,7 @@ You are an infrastructure monitoring and remediation agent. You run on a schedul
 
 - **Repos directory**: `$CLAUDEOPS_REPOS_DIR` (default: `/repos`) — mounted infrastructure repos
 - **State directory**: `$CLAUDEOPS_STATE_DIR` (default: `/state`) — cooldown state persists here
-- **Results directory**: `$CLAUDEOPS_RESULTS_DIR` (default: `/results`) — logs written here
+- **Results directory**: `$CLAUDEOPS_RESULTS_DIR` (default: `/results`) — timestamped run logs for post-hoc auditability (SPEC-0003 REQ-10). Each run produces a log file capturing all tool calls, check results, remediation actions, and cooldown state changes.
 - **Dry run mode**: `$CLAUDEOPS_DRY_RUN` — when `true`, observe only, never remediate
 
 ## Repo Discovery

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -78,7 +78,17 @@ while true; do
     RUN_START=$(date -u +%Y-%m-%dT%H:%M:%SZ)
     LOG_FILE="${RESULTS_DIR}/run-$(date +%Y%m%d-%H%M%S).log"
 
+    # Governing: SPEC-0003 REQ-10 — Post-Hoc Auditability
+    # All agent output is logged to timestamped files in $RESULTS_DIR.
+    # This captures tool calls, check results, remediation actions, and
+    # cooldown state changes for post-hoc compliance and incident review.
     echo "[${RUN_START}] Starting health check run..."
+    echo "--- Run metadata ---" >> "${LOG_FILE}"
+    echo "timestamp: ${RUN_START}" >> "${LOG_FILE}"
+    echo "tier: ${CLAUDEOPS_TIER}" >> "${LOG_FILE}"
+    echo "model: ${MODEL}" >> "${LOG_FILE}"
+    echo "dry_run: ${DRY_RUN}" >> "${LOG_FILE}"
+    echo "---" >> "${LOG_FILE}"
 
     # Merge repo MCP configs before each run
     echo "Merging MCP configurations..."
@@ -119,6 +129,7 @@ while true; do
         2>&1 | tee -a "${LOG_FILE}" || true  # Governing: SPEC-0010 REQ-10 (Error Handling — || true prevents set -e from terminating loop)
 
     RUN_END=$(date -u +%Y-%m-%dT%H:%M:%SZ)
-    echo "[${RUN_END}] Run complete. Sleeping ${INTERVAL}s..."
+    echo "[${RUN_END}] Run complete. Log: ${LOG_FILE}" | tee -a "${LOG_FILE}"
+    echo "[${RUN_END}] Sleeping ${INTERVAL}s..."
     sleep "${INTERVAL}"
 done

--- a/prompts/tier1-observe.md
+++ b/prompts/tier1-observe.md
@@ -391,6 +391,20 @@ Read and follow `/app/skills/events.md` for event marker format and guidelines.
 <!-- Governing: SPEC-0015 "Prompt Integration for Memory Markers" — instructs LLM to emit [MEMORY:category:service] markers -->
 Read and follow `/app/skills/memories.md` for memory marker format, categories, and guidelines.
 
+## Auditability
+
+<!-- Governing: SPEC-0003 REQ-10 — Post-Hoc Auditability -->
+
+All output from this session is captured to a timestamped log file in `/results/` for post-hoc review. To support compliance and incident analysis, your output MUST include:
+
+1. **Check results**: For every service checked, include the service name, check type, result (status code, response time), and healthy/degraded/down classification
+2. **Tool calls**: When executing commands (curl, dig, ssh, etc.), include the command and its outcome in your output
+3. **Cooldown state changes**: When reading or updating cooldown state, note the current state and any changes made
+4. **Escalation decisions**: If escalating to a higher tier, document what failed, why escalation is needed, and what context is being passed
+5. **Errors and exceptions**: Log any unexpected errors, timeouts, or access issues encountered during the run
+
+An operator reviewing the log file after the fact MUST be able to reconstruct what was checked, what was found, and what actions were taken (or not taken and why).
+
 ## Output Format
 
 Your final output is rendered as **Markdown** in the dashboard (with full GFM support: tables, task lists, etc.). Write a clean, readable summary — not console logs or raw text dumps. Emojis are encouraged where they aid readability.

--- a/prompts/tier2-investigate.md
+++ b/prompts/tier2-investigate.md
@@ -398,6 +398,20 @@ Current state: <service status and any relevant details>" \
 
 The human attention alert body MUST include: issue description, what was attempted, why remediation was stopped, and current system state or recommended next steps.
 
+## Auditability
+
+<!-- Governing: SPEC-0003 REQ-10 — Post-Hoc Auditability -->
+
+All output from this session is captured to a timestamped log file in `/results/` for post-hoc review. To support compliance and incident analysis, your output MUST include:
+
+1. **Investigation findings**: For every service investigated, include the root cause analysis, commands run, and their output summaries
+2. **Remediation actions**: For every remediation attempted, include the exact command executed, the outcome (success/failure), and the verification result
+3. **Cooldown state changes**: When reading or updating cooldown state, note the current state (restart counts, timestamps) and any changes made
+4. **Escalation decisions**: If escalating to Tier 3, document what was tried, why it failed, and what context is being passed via the handoff file
+5. **Errors and exceptions**: Log any unexpected errors, access issues, or tool failures encountered during investigation or remediation
+
+An operator reviewing the log file after the fact MUST be able to reconstruct what was investigated, what remediation was attempted, and what the verification outcome was.
+
 ## Output Format
 
 Your final output is rendered as **Markdown** in the dashboard (with full GFM support: tables, task lists, etc.). Write a clean, readable report — not console logs or raw text dumps. Emojis are encouraged where they aid readability.

--- a/prompts/tier3-remediate.md
+++ b/prompts/tier3-remediate.md
@@ -389,6 +389,20 @@ Current system state: <summary>" \
 
 The human attention alert body MUST include: issue description, what was attempted, why remediation failed or was stopped, and current system state with recommended next steps.
 
+## Auditability
+
+<!-- Governing: SPEC-0003 REQ-10 — Post-Hoc Auditability -->
+
+All output from this session is captured to a timestamped log file in `/results/` for post-hoc review. To support compliance and incident analysis, your output MUST include:
+
+1. **Root cause analysis**: Document the full root cause determination, including what evidence was examined (logs, metrics, container state)
+2. **Remediation actions**: For every remediation attempted (Ansible playbooks, Helm upgrades, container recreation, multi-service recovery), include the exact commands executed, their output summaries, and the verification result
+3. **Cooldown state changes**: When reading or updating cooldown state, note the current state (restart/redeployment counts, timestamps) and any changes made
+4. **Failed remediation details**: If remediation fails, document what was tried, why it failed, and what human action is recommended
+5. **Errors and exceptions**: Log any unexpected errors, access issues, or tool failures encountered during remediation
+
+An operator reviewing the log file after the fact MUST be able to reconstruct the full remediation timeline: what was the root cause, what actions were taken, what succeeded, what failed, and what requires human follow-up.
+
 ## Output Format
 
 Your final output is rendered as **Markdown** in the dashboard (with full GFM support: tables, task lists, etc.). Write a clean, readable report — not console logs or raw text dumps. Emojis are encouraged where they aid readability.


### PR DESCRIPTION
Closes #296
Part of epic #198
Part of SPEC-0003

## Summary

- Adds run metadata (timestamp, tier, model, dry_run) to the log file header in `entrypoint.sh` for structured post-hoc review
- Adds **Auditability** sections to all three tier prompts (`tier1-observe.md`, `tier2-investigate.md`, `tier3-remediate.md`) with tier-specific instructions for what must be included in output for audit compliance
- Updates `CLAUDE.md` Results directory description to reference SPEC-0003 REQ-10 and document what log files capture
- Logs the log file path at run completion for traceability

## Test plan

- [ ] Verify `go vet ./...` passes (confirmed locally)
- [ ] Verify `go test ./... -count=1 -race` passes (confirmed locally)
- [ ] Review that `entrypoint.sh` writes run metadata to log file before agent invocation
- [ ] Review that each tier prompt has an Auditability section with governing comment
- [ ] Review that Tier 1 auditability covers: check results, tool calls, cooldown state, escalation decisions
- [ ] Review that Tier 2 auditability covers: investigation findings, remediation actions, cooldown state, escalation decisions
- [ ] Review that Tier 3 auditability covers: root cause analysis, remediation actions, cooldown state, failed remediation details

🤖 Generated with [Claude Code](https://claude.com/claude-code)