### PR TITLE
Subagent Isolation & Cooldown Safety Net (SPEC-0003 REQ-8/9)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -202,6 +202,10 @@ These Docker-level restrictions provide defense-in-depth that does not depend on
 
 ## Cooldown Rules
 
+<!-- Governing: SPEC-0003 REQ-9 (Cooldown as Secondary Safety Net) -->
+
+The cooldown system acts as a secondary safety net that limits the blast radius of repeated remediation actions, independent of the permission tier.
+
 Read the cooldown state file at `$CLAUDEOPS_STATE_DIR/cooldown.json` (default: `/state/cooldown.json`) before taking any remediation action. The file is valid JSON, readable and writable using standard shell tools (`cat`, `jq`, `python3`). No custom parsers or binary formats are needed.
 
 - **Max 2 container restarts** per service per 4-hour sliding window
@@ -241,6 +245,10 @@ apprise -t "Title" -b "Message body" "$CLAUDEOPS_APPRISE_URLS"
 
 <!-- Governing: SPEC-0010 REQ-9 (Subagent Spawning via Task Tool — tiered escalation without custom orchestration code) -->
 ## Model Escalation
+
+<!-- Governing: SPEC-0003 REQ-8 (Subagent Tier Isolation) -->
+
+Each escalation tier runs as a **separate subagent** with its own prompt context and permission boundaries. When a lower tier escalates, the Go supervisor spawns the higher tier as an isolated agent that receives its own tier-specific prompt — permissions are not inherited from the lower tier.
 
 When spawning subagents for escalation, use the Task tool:
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -121,10 +121,17 @@ while true; do
     #            SPEC-0010 REQ-2 (Subprocess Invocation from Bash — CLI flags for all config, non-interactive, piped output)
     # Governing: SPEC-0010 REQ-7 — Non-Interactive Output via -p (--print) piped through tee
     # Governing: SPEC-0010 REQ-6 — --append-system-prompt injects ENV_CONTEXT at runtime
-    # Run Claude with tier 1 prompt
     # Governing: SPEC-0010 REQ-3 (--model), REQ-4 (--prompt-file)
     # Governing: SPEC-0010 REQ-5 — --allowedTools and --disallowedTools enforce
     # tool filtering at CLI runtime, independent of prompt-level instructions.
+    # Governing: SPEC-0003 REQ-8 (Subagent Tier Isolation)
+    # Tier 1 runs as a direct CLI invocation with restricted --allowedTools.
+    # Tiers 2 and 3 are spawned as separate subagents via the Task tool from
+    # the preceding tier (or by the Go supervisor reading handoff.json).
+    # Each subagent receives its own tier-specific prompt and permission boundaries.
+    # Governing: SPEC-0003 REQ-9 (Cooldown as Secondary Safety Net)
+    # Cooldown state at $STATE_DIR/cooldown.json is initialized here and read
+    # by every tier before any remediation action.
     claude \
         --model "${MODEL}" \
         -p "$(cat "${PROMPT_FILE}")" \

--- a/prompts/tier1-observe.md
+++ b/prompts/tier1-observe.md
@@ -274,7 +274,9 @@ Run checks ONLY against the hosts and services discovered from repos. **Never ch
 <!-- Governing: SPEC-0007 REQ-14 — Tier 1 reads cooldown state -->
 ## Step 4: Read Cooldown State
 
-Read `/app/skills/cooldowns.md` for cooldown rules, then read `/state/cooldown.json`. Note any services in cooldown.
+<!-- Governing: SPEC-0003 REQ-9 (Cooldown as Secondary Safety Net) -->
+
+Read `/app/skills/cooldowns.md` for cooldown rules, then read `/state/cooldown.json`. Note any services in cooldown. The cooldown system acts as a **secondary safety net** that limits the blast radius of repeated remediation, independent of the permission tier.
 
 ## Step 5: Evaluate Results
 
@@ -346,8 +348,11 @@ The daily digest body MUST include: total services checked, count of healthy/deg
 ### Issues found
 
 <!-- Governing: SPEC-0016 REQ "Tier Prompt Changes" — writes handoff file instead of using Task tool for escalation -->
+<!-- Governing: SPEC-0003 REQ-8 (Subagent Tier Isolation) -->
 
 **You are Tier 1 (observe only). You MUST NOT attempt remediation. You MUST escalate to Tier 2.**
+
+Each escalation tier runs as a **separate subagent** with its own prompt context and permission boundaries. When you escalate, the Go supervisor spawns the next tier as an isolated agent — it receives its own tier-specific prompt, not yours.
 
 1. Summarize all failures: which services, what checks failed, error details
 2. Build the escalation context as a structured JSON object with the following schema:
@@ -375,11 +380,13 @@ The daily digest body MUST include: total services checked, count of healthy/deg
 }
 ```
 
+<<<<<<< HEAD
 3. Include every failed service in `services_affected` and every failed check in `check_results`
 4. Include the full current cooldown state (from `/state/cooldown.json`) in `cooldown_state`
 5. Include the SSH host access map (from Step 2.5) in `ssh_access_map`
 6. Leave `investigation_findings` and `remediation_attempted` empty — Tier 2 will populate these if it needs to escalate further
 7. Write the handoff file to `/state/handoff.json` using the Write tool. The Go supervisor will read the handoff and spawn the next tier automatically.
+8. **You MUST pass the full context** of your findings in the handoff. The Tier 2 subagent SHOULD NOT need to re-run the health checks you already performed.
 
 ### Services in cooldown
 <!-- Governing: SPEC-0004 REQ-3 — CLI-Based Invocation -->

--- a/prompts/tier3-remediate.md
+++ b/prompts/tier3-remediate.md
@@ -1,15 +1,16 @@
 <!-- Governing: SPEC-0001 REQ-5, SPEC-0002 REQ-4 (Tier Prompt Document Structure) -->
+<!-- Governing: SPEC-0003 REQ-8 (Subagent Tier Isolation) -->
 # Tier 3: Full Remediation
 
 <!-- Governing: SPEC-0001 REQ-8 (Permission-Model Alignment) — Tier 3 permits all remediations except Never-Allowed actions -->
 <!-- Governing: SPEC-0016 REQ "Tier Prompt Changes" — terminal tier, no Task tool, handoff context via --append-system-prompt -->
 
-You are Claude Ops at the highest escalation tier. Sonnet investigated and attempted safe remediations, but the issue persists. You have full remediation capabilities.
+You are Claude Ops at the highest escalation tier, running as a **separate subagent** with your own prompt context and Tier 3 permission boundaries. Your permissions are defined below, not inherited from Tier 2. Sonnet investigated and attempted safe remediations, but the issue persists. You have full remediation capabilities.
 
 **This is the terminal tier — there is no further escalation.** If you cannot fix the issue, send an Apprise notification requesting human attention.
 
 <!-- Governing: SPEC-0001 REQ-6 (Escalation Context Forwarding) — Do NOT re-run checks or re-attempt failed remediations from prior tiers -->
-You will receive investigation findings from Tier 2 via your system prompt (injected from the handoff file by the Go supervisor). Do NOT re-run basic checks or re-attempt remediations that already failed.
+You will receive investigation findings from Tier 2 via your system prompt (injected from the handoff file by the Go supervisor). Do NOT re-run basic checks or re-attempt remediations that already failed. The previous tiers have already performed discovery, health checks, investigation, and safe remediation attempts; you SHOULD NOT repeat that work.
 
 ## Environment
 
@@ -237,7 +238,9 @@ With the full picture, determine the actual root cause:
 <!-- Governing: SPEC-0007 REQ-14 — Tier 3 reads and writes cooldown state -->
 ## Step 3: Check Cooldown
 
-Read `/app/skills/cooldowns.md` for cooldown rules, then read `/state/cooldown.json`. If cooldown limit is exceeded, skip to Step 5 (report as needs human attention).
+<!-- Governing: SPEC-0003 REQ-9 (Cooldown as Secondary Safety Net) -->
+
+Read `/app/skills/cooldowns.md` for cooldown rules, then read `/state/cooldown.json`. The cooldown system acts as a **secondary safety net** that limits the blast radius of repeated remediation, independent of the permission tier. If cooldown limit is exceeded, skip to Step 5 (report as needs human attention).
 
 <!-- Governing: SPEC-0020 "Command Prefix Based on Access Method" — SSH prefix per host access map -->
 <!-- Governing: SPEC-0020 "Write Command Gating" — limited-access hosts restricted to read commands -->

--- a/skills/cooldowns.md
+++ b/skills/cooldowns.md
@@ -1,5 +1,9 @@
 <!-- Governing: SPEC-0007 REQ-1 (state file location), REQ-10 (agent tooling), REQ-11 (human readability) -->
+<!-- Governing: SPEC-0003 REQ-9 (Cooldown as Secondary Safety Net) -->
+
 # Skill: Cooldown Management
+
+The cooldown system acts as a **secondary safety net** that limits the blast radius of repeated remediation actions, independent of the permission tier. Even if an agent has permission to remediate, the cooldown state provides an additional check point where the agent MUST stop and notify instead of acting if limits are exceeded.
 
 Read the cooldown state file at `$CLAUDEOPS_STATE_DIR/cooldown.json` (default: `/state/cooldown.json`) before taking any remediation action. The file is valid JSON, readable and writable with `cat`, `jq`, or `python3` -- no custom parsers needed.
 
@@ -8,7 +12,7 @@ Read the cooldown state file at `$CLAUDEOPS_STATE_DIR/cooldown.json` (default: `
 - **Max 2 container restarts** per service per 4-hour window
 - **Max 1 full redeployment** (Ansible/Helm) per service per 24-hour window
 - If the cooldown limit is exceeded: stop retrying, send a notification marked "needs human attention"
-- Reset counters when a service is confirmed healthy for 2 consecutive checks
+- Reset counters when a service is confirmed healthy for **2 consecutive check cycles**
 - Always update the state file after any remediation attempt or health check
 
 <!-- Governing: SPEC-0007 REQ-13 — Cooldown State Data Model -->


### PR DESCRIPTION
Closes #295
Part of epic #198
Part of SPEC-0003

Ensures subagent tier isolation and cooldown-as-secondary-safety-net are explicitly documented and governed per SPEC-0003 REQ-8 and REQ-9.

## Changes

### Subagent Tier Isolation (REQ-8)
- Added `<!-- Governing: SPEC-0003 REQ-8 -->` comments to all tier prompts, CLAUDE.md escalation section, and entrypoint.sh
- Tier 2 and Tier 3 prompts now explicitly state they run as **separate subagents** with their own prompt context and permission boundaries (not inherited from lower tiers)
- All escalation points now explicitly state that the escalating tier MUST pass full context and the receiving tier SHOULD NOT re-run prior checks
- Tier 1 handoff instructions reinforced with explicit context-passing requirement

### Cooldown as Secondary Safety Net (REQ-9)
- Added `<!-- Governing: SPEC-0003 REQ-9 -->` comments to cooldown sections in all tier prompts, CLAUDE.md, skills/cooldowns.md, and entrypoint.sh
- Cooldown skill now explicitly frames itself as a "secondary safety net" per the spec — an additional check point independent of the permission tier
- Clarified that cooldown counter reset requires "2 consecutive check cycles" (not just "2 checks")