### PR TITLE
Configuration & Graceful Degradation (SPEC-0004 REQ-1/2/4/8)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,6 +2,8 @@ ANTHROPIC_API_KEY=
 # ANTHROPIC_BASE_URL=https://litellm.example.com
 CLAUDEOPS_DRY_RUN=true
 CLAUDEOPS_INTERVAL=900
+# Governing: SPEC-0004 REQ-1 (single env var for all notification targets)
+# Comma-separated Apprise URLs. Unset = notifications silently skipped (REQ-2).
 # CLAUDEOPS_APPRISE_URLS=
 # CLAUDEOPS_SUMMARY_MODEL=haiku
 # CLAUDEOPS_BROWSER_ALLOWED_ORIGINS=

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -181,6 +181,8 @@ Read the cooldown state file at `$CLAUDEOPS_STATE_DIR/cooldown.json` before taki
 
 ## Notifications via Apprise
 
+<!-- Governing: SPEC-0004 REQ-1 (single env var), REQ-2 (graceful degradation when unset) -->
+
 Notifications are sent using the `apprise` CLI, which supports 80+ services (email, ntfy, Slack, Discord, Telegram, etc.) through URL-based configuration.
 
 ```bash

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,6 +25,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     python3-venv \
     && rm -rf /var/lib/apt/lists/*
 
+# Governing: SPEC-0004 REQ-8 (Docker Image Installation — apprise via pip3)
 # Apprise for notifications (supports 80+ services)
 RUN pip3 install --break-system-packages --retries 3 --timeout 120 apprise
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -81,7 +81,10 @@ while true; do
     ENV_CONTEXT="${ENV_CONTEXT} CLAUDEOPS_TIER2_MODEL=${CLAUDEOPS_TIER2_MODEL:-sonnet}"
     ENV_CONTEXT="${ENV_CONTEXT} CLAUDEOPS_TIER3_MODEL=${CLAUDEOPS_TIER3_MODEL:-opus}"
 
-    # Pass Apprise URLs if configured
+    # Governing: SPEC-0004 REQ-1 (single env var config),
+    #            SPEC-0004 REQ-2 (graceful degradation — only pass when set),
+    #            SPEC-0004 REQ-4 (env var passthrough to agent context)
+    # Pass Apprise URLs if configured; skip silently when unset (REQ-2).
     if [ -n "${CLAUDEOPS_APPRISE_URLS:-}" ]; then
         ENV_CONTEXT="${ENV_CONTEXT} CLAUDEOPS_APPRISE_URLS=${CLAUDEOPS_APPRISE_URLS}"
     fi


### PR DESCRIPTION
Closes #297
Part of epic #258
Part of SPEC-0004

## Summary

- Added SPEC-0004 governing comments to trace existing Apprise notification implementation back to spec requirements
- **Dockerfile**: `# Governing: SPEC-0004 REQ-8` on apprise pip install line (python3, pip3, and apprise CLI already installed)
- **entrypoint.sh**: `# Governing: SPEC-0004 REQ-1, REQ-2, REQ-4` on the Apprise URL passthrough block (already conditionally passes `CLAUDEOPS_APPRISE_URLS` only when set)
- **CLAUDE.md**: `<!-- Governing: SPEC-0004 REQ-1, REQ-2 -->` on the "Notifications via Apprise" section
- **.env.example**: Added governing comment and description for `CLAUDEOPS_APPRISE_URLS`

All four requirements were already fully implemented; this PR adds traceability.

## Test plan

- [ ] `go vet ./...` passes
- [ ] `go test ./... -count=1 -race` passes
- [ ] Verify `Dockerfile` installs apprise via pip3
- [ ] Verify `entrypoint.sh` conditionally passes `CLAUDEOPS_APPRISE_URLS` only when set
- [ ] Verify `.env.example` documents the env var
- [ ] Verify `docker-compose.yaml` includes `CLAUDEOPS_APPRISE_URLS` in environment

🤖 Generated with [Claude Code](https://claude.com/claude-code)