### PR TITLE
Tier-Specific Notification Permissions (SPEC-0004 REQ-7)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -198,6 +198,12 @@ apprise -t "Title" -b "Message body" "$CLAUDEOPS_APPRISE_URLS"
 - **Auto-remediated**: immediately after successful remediation — what was wrong, what you did, verification result
 - **Needs attention**: immediately when remediation fails or cooldown exceeded — what's wrong, what you tried, why it didn't work
 
+<!-- Governing: SPEC-0004 REQ-7 — Tier-Specific Notification Permissions -->
+### Notification permissions by tier
+- **Tier 1** MAY send daily digest notifications and cooldown-exceeded alerts.
+- **Tier 2** MUST send auto-remediation reports after successful remediations. MUST send human attention alerts when remediation fails or cooldown limits are exceeded.
+- **Tier 3** MUST send a detailed notification at the end of every execution, regardless of outcome.
+
 ## Model Escalation
 
 When spawning subagents for escalation, use the Task tool:

--- a/prompts/tier1-observe.md
+++ b/prompts/tier1-observe.md
@@ -208,6 +208,16 @@ Browser authentication is NOT permitted at Tier 1. You may check if a login page
 
 If a service requires browser-based investigation, escalate to Tier 2 via the handoff file.
 
+<!-- Governing: SPEC-0004 REQ-7 — Tier-Specific Notification Permissions -->
+## Notification Permissions
+
+Tier 1 MAY send the following notifications via Apprise (if `$CLAUDEOPS_APPRISE_URLS` is configured):
+
+- **Daily digest** — a once-per-day summary of all health check results and uptime statistics.
+- **Cooldown-exceeded alerts** — when a service is in cooldown and requires human attention.
+
+Tier 1 MUST NOT send auto-remediation reports or detailed remediation notifications. Those are Tier 2 and Tier 3 responsibilities.
+
 ## Step 6: Report or Escalate
 
 ### All healthy

--- a/prompts/tier2-investigate.md
+++ b/prompts/tier2-investigate.md
@@ -260,6 +260,14 @@ After every remediation attempt (restart or redeployment), emit a `[COOLDOWN:...
 [COOLDOWN:restart:sonarr] failure — Restarted but OOM killed again within 2 minutes
 ```
 
+<!-- Governing: SPEC-0004 REQ-7 — Tier-Specific Notification Permissions -->
+## Notification Permissions
+
+Tier 2 MUST send the following notifications via Apprise (if `$CLAUDEOPS_APPRISE_URLS` is configured):
+
+- **Auto-remediation reports** — sent immediately after a successful remediation, describing the issue, action taken, and verification result.
+- **Human attention alerts** — sent immediately when remediation fails or cooldown limits are exceeded, indicating manual intervention is required.
+
 ## Step 5: Report Results
 
 ### Fixed

--- a/prompts/tier3-remediate.md
+++ b/prompts/tier3-remediate.md
@@ -274,6 +274,16 @@ After every remediation attempt (restart, redeployment, Ansible playbook, Helm u
 [COOLDOWN:restart:postgres] failure — Restarted but connection refused persists
 ```
 
+<!-- Governing: SPEC-0004 REQ-7 — Tier-Specific Notification Permissions -->
+## Notification Permissions
+
+Tier 3 MUST send a detailed notification via Apprise at the end of every execution, regardless of outcome. This includes:
+
+- **Remediation reports** — sent after any remediation attempt (successful or not), including root cause analysis, actions taken, verification results, and follow-up recommendations.
+- **Human attention alerts** — sent when remediation fails or cannot be completed, indicating manual intervention is required.
+
+Tier 3 MUST always send a notification. There is no silent exit at this tier.
+
 ## Step 5: Report
 
 ALWAYS send a detailed report via Apprise, regardless of outcome.


### PR DESCRIPTION
Closes #300
Part of epic #258
Part of SPEC-0004

## Summary

- Adds explicit "Notification Permissions" sections to all three tier prompt files, each with `<!-- Governing: SPEC-0004 REQ-7 -->` comments.
- **Tier 1** (`prompts/tier1-observe.md`): MAY send daily digest and cooldown-exceeded alerts. MUST NOT send auto-remediation or detailed remediation notifications.
- **Tier 2** (`prompts/tier2-investigate.md`): MUST send auto-remediation reports after successful remediations. MUST send human attention alerts on failure or cooldown exceeded.
- **Tier 3** (`prompts/tier3-remediate.md`): MUST send a detailed notification at the end of every execution, regardless of outcome. No silent exit.
- Adds a "Notification permissions by tier" subsection to `CLAUDE.md` under "Notifications via Apprise" as the authoritative reference.

## Test plan

- [x] `go vet ./...` passes
- [x] `go test ./... -count=1 -race` passes
- [ ] Review that Tier 1 notification permissions match REQ-7 (MAY daily digest + cooldown alerts)
- [ ] Review that Tier 2 notification permissions match REQ-7 (MUST auto-remediation + human attention)
- [ ] Review that Tier 3 notification permissions match REQ-7 (MUST always notify)