### PR TITLE
CLI Invocation & No-Retry Policy (SPEC-0004 REQ-3/10)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -193,19 +193,20 @@ Read the cooldown state file at `$CLAUDEOPS_STATE_DIR/cooldown.json` (default: `
 
 ## Notifications via Apprise
 
-<!-- Governing: SPEC-0004 REQ-1 (single env var), REQ-2 (graceful degradation when unset) -->
+<!-- Governing: SPEC-0004 REQ-1 (single env var), REQ-2 (graceful degradation when unset), REQ-3 (CLI-Based Invocation) -->
 
-Notifications are sent using the `apprise` CLI, which supports 80+ services (email, ntfy, Slack, Discord, Telegram, etc.) through URL-based configuration.
+Notifications are sent using the `apprise` CLI, which supports 80+ services (email, ntfy, Slack, Discord, Telegram, etc.) through URL-based configuration. Always invoke Apprise as a CLI command via Bash — never as a Python library or import.
 
 ```bash
 # Send a notification
 apprise -t "Title" -b "Message body" "$CLAUDEOPS_APPRISE_URLS"
-
-# Urgent notifications (services that support priority)
-apprise -t "Title" -b "Message body" "$CLAUDEOPS_APPRISE_URLS"
 ```
 
 `$CLAUDEOPS_APPRISE_URLS` contains one or more comma-separated Apprise URLs. If the variable is empty or unset, skip notifications silently (don't error).
+
+<!-- Governing: SPEC-0004 REQ-10 — No Delivery Guarantee or Retry -->
+
+**Reliability**: If an `apprise` invocation fails (non-zero exit code, network error, misconfigured URL), log the failure but do NOT retry the notification. Continue the current health check or remediation cycle normally. Notification delivery is best-effort — a failed notification MUST NOT block or interrupt operations.
 
 ### When to notify
 - **Daily digest**: once per day, summarize all checks and uptime stats

--- a/Dockerfile
+++ b/Dockerfile
@@ -30,6 +30,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 # Governing: SPEC-0004 REQ-8 (Docker Image Installation — apprise via pip3)
 # Governing: SPEC-0009 REQ "Dockerfile Structure" — apprise for notifications
 # Apprise for notifications (supports 80+ services)
+# Governing: SPEC-0004 REQ-3 — Installed as CLI tool, invoked via `apprise` command in agent Bash commands
 RUN pip3 install --break-system-packages --retries 3 --timeout 120 apprise
 
 # Governing: SPEC-0010 REQ-1 (CLI Installation via npm), SPEC-0009 REQ "Dockerfile Structure" — Claude Code CLI

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -98,6 +98,7 @@ while true; do
 
     # Governing: SPEC-0004 REQ-1 (single env var config),
     #            SPEC-0004 REQ-2 (graceful degradation — only pass when set),
+    #            SPEC-0004 REQ-3 (CLI-Based Invocation — agent invokes `apprise` CLI via Bash),
     #            SPEC-0004 REQ-4 (env var passthrough to agent context),
     #            SPEC-0010 REQ-6 — Apprise URLs conditionally included
     # Pass Apprise URLs if configured; skip silently when unset (REQ-2).

--- a/prompts/tier1-observe.md
+++ b/prompts/tier1-observe.md
@@ -313,6 +313,8 @@ When `$CLAUDEOPS_APPRISE_URLS` is empty or unset, skip all notifications silentl
 - Update `last_run` in the cooldown state file
 - If a daily digest is due (check `last_daily_digest`), compose and send one via Apprise (if configured):
 
+<!-- Governing: SPEC-0004 REQ-3 — CLI-Based Invocation -->
+
 ```bash
 apprise -t "Claude Ops: Daily Health Summary" \
   -b "Services checked: <count>
@@ -322,6 +324,8 @@ Down: <count> (<details if any>)
 In cooldown: <count>" \
   "$CLAUDEOPS_APPRISE_URLS"
 ```
+
+Always invoke `apprise` as a CLI command via Bash — never as a Python library or import. If the command fails, log the failure and continue — do not retry (SPEC-0004 REQ-10).
 
 The daily digest body MUST include: total services checked, count of healthy/degraded/down/in-cooldown services, and details for any non-healthy services.
 
@@ -367,6 +371,7 @@ The daily digest body MUST include: total services checked, count of healthy/deg
 7. Write the handoff file to `/state/handoff.json` using the Write tool. The Go supervisor will read the handoff and spawn the next tier automatically.
 
 ### Services in cooldown
+<!-- Governing: SPEC-0004 REQ-3 — CLI-Based Invocation -->
 - For services where cooldown limits are reached, send a human attention alert via Apprise (if configured):
 
 ```bash
@@ -379,6 +384,7 @@ Current state: <service status>" \
 ```
 
 The human attention alert body MUST include: issue description, cooldown state, and what was previously attempted.
+- If the Apprise invocation fails, log the failure and continue — do not retry (SPEC-0004 REQ-10)
 
 - Do not escalate — cooldown means we've already tried
 

--- a/prompts/tier2-investigate.md
+++ b/prompts/tier2-investigate.md
@@ -339,7 +339,9 @@ Tier 2 supports two notification event categories:
 When `$CLAUDEOPS_APPRISE_URLS` is empty or unset, skip all notifications silently (no errors). When set, it may contain multiple comma-separated Apprise URLs — the same notification is delivered to ALL configured targets simultaneously.
 
 ### Fixed
-Send an auto-remediation report via Apprise (if `$CLAUDEOPS_APPRISE_URLS` is set):
+<!-- Governing: SPEC-0004 REQ-3 — CLI-Based Invocation -->
+
+Send an auto-remediation report via Apprise (if `$CLAUDEOPS_APPRISE_URLS` is set). Always invoke `apprise` as a CLI command via Bash — never as a Python library or import:
 
 ```bash
 apprise -t "Claude Ops: Auto-remediated <service>" \
@@ -350,6 +352,10 @@ Status: <verification result, e.g. HTTP 200 OK (145ms)>" \
 ```
 
 The auto-remediation body MUST include: what was wrong (the detected issue), what action was taken (the remediation performed), and the verification result (post-remediation health check result).
+
+<!-- Governing: SPEC-0004 REQ-10 — No Delivery Guarantee or Retry -->
+
+If the `apprise` command fails (non-zero exit code), log the failure and continue — do NOT retry the notification. Notification delivery is best-effort and MUST NOT block the remediation cycle.
 
 ### Cannot fix (needs Tier 3)
 
@@ -386,7 +392,8 @@ Build the escalation context as a structured JSON object with the following sche
 - The Tier 3 agent MUST NOT re-run basic checks or re-attempt remediations that already failed
 
 ### Cannot fix (cooldown exceeded)
-Send a human attention alert via Apprise:
+<!-- Governing: SPEC-0004 REQ-3 — CLI-Based Invocation, REQ-10 — No Delivery Guarantee or Retry -->
+Send a human attention alert via Apprise. If the notification fails, log and continue — do not retry:
 
 ```bash
 apprise -t "Claude Ops: Needs human attention — <service>" \

--- a/prompts/tier3-remediate.md
+++ b/prompts/tier3-remediate.md
@@ -346,9 +346,11 @@ Tier 3 MUST always send a notification. There is no silent exit at this tier.
 
 ## Step 5: Report
 
+<!-- Governing: SPEC-0004 REQ-3 — CLI-Based Invocation -->
 <!-- Governing: SPEC-0004 REQ-5 — Three Notification Event Categories -->
 <!-- Governing: SPEC-0004 REQ-6 — Notification Message Format -->
 <!-- Governing: SPEC-0004 REQ-9 — Multiple Simultaneous Targets -->
+<!-- Governing: SPEC-0004 REQ-10 — No Delivery Guarantee or Retry -->
 
 ### Notification Event Categories
 
@@ -357,7 +359,9 @@ Tier 3 supports two notification event categories:
 1. **Tier 3 Remediation Report** — Sent after a successful remediation, including root cause analysis, step-by-step actions, verification, and follow-up recommendations.
 2. **Human Attention Alert** — Sent when remediation fails or cooldown limits are exceeded, indicating manual intervention is required.
 
-Tier 3 MUST always send a notification at the end of its execution, regardless of outcome. When `$CLAUDEOPS_APPRISE_URLS` is empty or unset, skip all notifications silently (no errors). When set, it may contain multiple comma-separated Apprise URLs — the same notification is delivered to ALL configured targets simultaneously.
+Tier 3 MUST always send a notification at the end of its execution, regardless of outcome. Always invoke `apprise` as a CLI command via Bash — never as a Python library or import. When `$CLAUDEOPS_APPRISE_URLS` is empty or unset, skip all notifications silently (no errors). When set, it may contain multiple comma-separated Apprise URLs — the same notification is delivered to ALL configured targets simultaneously.
+
+If any `apprise` invocation fails (non-zero exit code), log the failure and continue — do NOT retry the notification. Notification delivery is best-effort and MUST NOT block Tier 3 operations.
 
 ### Fixed
 


### PR DESCRIPTION
Closes #298
Part of epic #258
Part of SPEC-0004

## Summary

Ensures all Apprise notification invocations comply with SPEC-0004 requirements for CLI-based invocation and no-retry reliability:

- **REQ-3 (CLI-Based Invocation)**: Added `<!-- Governing: SPEC-0004 REQ-3 -->` comments to CLAUDE.md runbook, Dockerfile, entrypoint.sh, and all three tier prompts. Explicitly states that `apprise` must be invoked as a CLI command via Bash, never as a Python library or import.

- **REQ-10 (No Delivery Guarantee or Retry)**: Added `<!-- Governing: SPEC-0004 REQ-10 -->` comments with explicit no-retry instructions in the CLAUDE.md runbook and all tier prompts. If an `apprise` command fails (non-zero exit code), the agent logs the failure and continues the current cycle without retrying. Notification delivery is best-effort and must not block operations.

## Files Changed

- `CLAUDE.md` — Runbook notification section with governing comments and reliability policy
- `Dockerfile` — Governing comment on Apprise pip install line
- `entrypoint.sh` — Governing comment on Apprise URL passthrough
- `prompts/tier1-observe.md` — CLI examples for daily digest and cooldown notifications with no-retry policy
- `prompts/tier2-investigate.md` — No-retry policy for remediation and cooldown notifications
- `prompts/tier3-remediate.md` — CLI invocation and no-retry policy for all Tier 3 reports

## Test Plan

- [x] `go vet ./...` passes
- [x] `go test ./... -count=1 -race` passes
- [ ] Verify all notification sections have SPEC-0004 REQ-3 governing comments
- [ ] Verify no-retry policy is stated in all tier prompts