### PR TITLE
Event Categories & Message Format (SPEC-0004 REQ-5/6/9)

### DIFF
--- a/prompts/tier3-remediate.md
+++ b/prompts/tier3-remediate.md
@@ -276,18 +276,34 @@ After every remediation attempt (restart, redeployment, Ansible playbook, Helm u
 
 ## Step 5: Report
 
-ALWAYS send a detailed report via Apprise, regardless of outcome.
+<!-- Governing: SPEC-0004 REQ-5 — Three Notification Event Categories -->
+<!-- Governing: SPEC-0004 REQ-6 — Notification Message Format -->
+<!-- Governing: SPEC-0004 REQ-9 — Multiple Simultaneous Targets -->
+
+### Notification Event Categories
+
+Tier 3 supports two notification event categories:
+
+1. **Tier 3 Remediation Report** — Sent after a successful remediation, including root cause analysis, step-by-step actions, verification, and follow-up recommendations.
+2. **Human Attention Alert** — Sent when remediation fails or cooldown limits are exceeded, indicating manual intervention is required.
+
+Tier 3 MUST always send a notification at the end of its execution, regardless of outcome. When `$CLAUDEOPS_APPRISE_URLS` is empty or unset, skip all notifications silently (no errors). When set, it may contain multiple comma-separated Apprise URLs — the same notification is delivered to ALL configured targets simultaneously.
 
 ### Fixed
 
 ```bash
 apprise -t "Claude Ops: Remediated <service> (Tier 3)" \
-  -b "Root cause: <what was wrong>
-Actions taken: <step by step>
-Verification: <result>
-Recommendations: <any follow-up needed>" \
+  -b "Root cause: <root cause analysis>
+Actions taken:
+  1. <step 1>
+  2. <step 2>
+  ...
+Verification: <post-remediation health check result>
+Recommendations: <follow-up actions needed>" \
   "$CLAUDEOPS_APPRISE_URLS"
 ```
+
+The Tier 3 remediation body MUST include: root cause analysis, step-by-step actions taken, verification result, and recommendations for follow-up.
 
 ### Not fixed
 
@@ -301,6 +317,8 @@ Recommended next steps: <what a human should do>
 Current system state: <summary>" \
   "$CLAUDEOPS_APPRISE_URLS"
 ```
+
+The human attention alert body MUST include: issue description, what was attempted, why remediation failed or was stopped, and current system state with recommended next steps.
 
 ## Output Format
 


### PR DESCRIPTION
Closes #299
Part of epic #258
Part of SPEC-0004

## Summary

- Added formal "Notification Event Categories" sections with governing comments to all three tier prompt files
- **Tier 1** (`tier1-observe.md`): Defined two event categories (Daily Digest, Human Attention Alert) with full message format templates including required fields per REQ-6 (service counts, health status details for digests; issue description, cooldown state, prior attempts for alerts)
- **Tier 2** (`tier2-investigate.md`): Defined two event categories (Auto-Remediation Report, Human Attention Alert) with expanded message format templates including required fields (issue/action/verification for auto-remediation; issue/attempted/why-stopped/state for alerts)
- **Tier 3** (`tier3-remediate.md`): Defined two event categories (Tier 3 Remediation Report, Human Attention Alert) with required fields (root cause/actions/verification/recommendations for remediation; full investigation context for alerts). Tier 3 MUST always send a notification regardless of outcome.
- All tiers explicitly document that comma-separated `$CLAUDEOPS_APPRISE_URLS` delivers to ALL configured targets simultaneously (REQ-9)
- All tiers handle graceful degradation: skip notifications silently when `$CLAUDEOPS_APPRISE_URLS` is empty or unset
- Added `<!-- Governing: SPEC-0004 REQ-5/6/9 -->` comments to trace implementation back to spec

## Test plan

- [x] `go vet ./...` passes
- [x] `go test ./... -count=1 -race` passes
- [ ] Verify each tier's notification section defines the correct event categories per REQ-5
- [ ] Verify message formats include all required fields per REQ-6
- [ ] Verify multi-target documentation per REQ-9