### PR TITLE
Repo Discovery & Manifest (SPEC-0005 REQ-1/2/3/8)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -99,16 +99,18 @@ You are an infrastructure monitoring and remediation agent. You run on a schedul
 
 ## Repo Discovery
 
-Infrastructure repos are mounted under `/repos/`. Each subdirectory is a separate repo.
+<!-- Governing: SPEC-0005 REQ-1 (Repo Discovery via Directory Scanning), REQ-2 (Manifest Discovery), REQ-3 (Manifest Content Structure), REQ-8 (Fallback Discovery) -->
+
+Infrastructure repos are mounted under `/repos/`. Each subdirectory is a separate repo. The agent MUST scan all immediate subdirectories at the start of each monitoring cycle so newly mounted or removed repos are detected without a container restart.
 
 For each repo, look for:
-1. **`CLAUDE-OPS.md`** at the repo root — describes what the repo is, its capabilities, and rules
+1. **`CLAUDE-OPS.md`** at the repo root — the manifest describes what the repo is, its capabilities (with tier requirements), and rules the agent MUST follow. The manifest SHOULD include Kind, Capabilities, and Rules sections.
 2. **`.claude-ops/`** directory — contains repo-specific extensions:
    - `.claude-ops/checks/` — additional health checks (run alongside built-in checks)
    - `.claude-ops/playbooks/` — remediation procedures specific to this repo's services
    - `.claude-ops/skills/` — custom capabilities (maintenance tasks, reporting, etc.)
 
-If neither exists, read top-level files (README, directory structure) to infer what the repo is.
+If neither exists, infer the repo's purpose by reading `README.md`, examining directory structure, and inspecting config files. Record the repo as discovered with limited context — this is not an error.
 
 **If no repos are found (empty or missing repos directory), stop immediately. Do not fall back to scanning the local system.** Only check services explicitly defined in a mounted repo's inventory. Never discover services by other means — no `docker ps`, no process scanning, no network probing. If it's not in a repo, it doesn't exist to you.
 

--- a/prompts/tier1-observe.md
+++ b/prompts/tier1-observe.md
@@ -103,18 +103,38 @@ These log lines MUST appear in the output whenever a skill is invoked so that to
 
 ## Step 1: Discover Infrastructure Repos
 
-Scan `/repos` for mounted repositories:
+<!-- Governing: SPEC-0005 REQ-1 (Repo Discovery via Directory Scanning) -->
+
+Scan `/repos` for mounted repositories. This scan MUST be performed every cycle so that newly mounted or removed repos are detected without requiring a container restart.
 
 1. List subdirectories: `ls /repos/`
 2. **If `/repos` is empty or does not exist, output "No repos found — nothing to check" and EXIT IMMEDIATELY. Do NOT fall back to scanning the local system, running docker ps, or checking any services not defined in a mounted repo.**
-3. For each subdirectory, check for a `CLAUDE-OPS.md` manifest
-4. If present, read it to understand the repo's purpose and capabilities
-5. If absent, read top-level files to infer what it is
+
+<!-- Governing: SPEC-0005 REQ-2 (Manifest Discovery and Reading) -->
+
+3. For each subdirectory, check for a `CLAUDE-OPS.md` manifest at the repo root
+4. If present, read it and incorporate the repo's declared capabilities and rules into the current cycle's context. The manifest SHOULD include:
+   - **Kind**: The type of infrastructure repo (e.g., "Ansible infrastructure", "Docker images", "Helm charts")
+   - **Capabilities**: What the repo provides (e.g., `service-discovery`, `redeployment`, `image-inspection`), including which tiers are required for each
+   - **Rules**: Constraints the agent MUST follow when interacting with this repo (e.g., "never modify files", "playbooks require Tier 3", "always use `--limit`")
+
+<!-- Governing: SPEC-0005 REQ-3 (Manifest Content Structure) -->
+
+   The agent MUST respect all rules declared in a repo's manifest throughout the monitoring cycle across all tiers. If the manifest declares a capability is restricted to a specific tier, lower-tier agents MUST NOT use that capability and MUST escalate instead.
+
+<!-- Governing: SPEC-0005 REQ-8 (Fallback Discovery for Repos Without Extensions) -->
+
+5. If no `CLAUDE-OPS.md` is found, attempt to infer the repo's purpose by:
+   - Reading `README.md` if present
+   - Examining the directory structure (look for `ansible.cfg`, `docker-compose.yml`, `Chart.yaml`, etc.)
+   - Inspecting top-level configuration files for clues about the repo's function
+   - Record that the repo was discovered but has limited operational context — this is not an error
+
 6. Check for a `.claude-ops/` directory containing repo-specific extensions:
    - `.claude-ops/checks/` — additional health checks to run alongside built-in checks
    - `.claude-ops/playbooks/` — remediation procedures specific to this repo's services
    - `.claude-ops/skills/` — custom capabilities (maintenance tasks, reporting, etc.)
-7. Build a map of available repos, their capabilities, and any custom checks/playbooks/skills
+7. Build a unified map of available repos, their capabilities, extensions, and rules
 
 Find the inventory from whichever repo has `service-discovery` capability. **Only check services that are explicitly defined in a discovered repo's inventory. Never discover services by other means (docker ps, process lists, network scanning, etc.).**
 


### PR DESCRIPTION
Closes #301
Part of epic #2
Part of SPEC-0005

Ensures tier1 prompt scans CLAUDEOPS_REPOS_DIR each cycle, reads CLAUDE-OPS.md manifests, respects manifest structure, and falls back to file inference for repos without manifests.

## Changes

### `prompts/tier1-observe.md`
- Added `<!-- Governing: SPEC-0005 REQ-1 -->` for directory scanning (scan MUST occur every cycle)
- Added `<!-- Governing: SPEC-0005 REQ-2 -->` for manifest discovery and reading
- Added `<!-- Governing: SPEC-0005 REQ-3 -->` for manifest content structure — explicitly describes expected sections (Kind, Capabilities with tier requirements, Rules) and that all manifest rules MUST be respected across all tiers
- Added `<!-- Governing: SPEC-0005 REQ-8 -->` for fallback discovery — expanded from "read top-level files" to explicit steps: read README.md, examine directory structure for known config files (ansible.cfg, docker-compose.yml, Chart.yaml), inspect config files, record with limited context (not an error)
- Changed "Build a map" to "Build a unified map" to align with SPEC-0005 REQ-12 terminology

### `CLAUDE.md`
- Added governing comment referencing SPEC-0005 REQ-1/2/3/8 to Repo Discovery section
- Added explicit "scan each cycle" language for REQ-1
- Expanded manifest description to mention Kind, Capabilities, and Rules sections for REQ-3
- Expanded fallback discovery to list specific inference methods for REQ-8