### PR TITLE
File Storage & Initialization (SPEC-0007 REQ-1/2/3/10/11)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -169,9 +169,10 @@ These actions ALWAYS require a human. Never do any of these:
 - Drop or truncate database tables
 - Modify this runbook or any prompt files
 
+<!-- Governing: SPEC-0007 REQ-1 (state file location), REQ-10 (agent tooling), REQ-11 (human readability) -->
 ## Cooldown Rules
 
-Read the cooldown state file at `$CLAUDEOPS_STATE_DIR/cooldown.json` before taking any remediation action.
+Read the cooldown state file at `$CLAUDEOPS_STATE_DIR/cooldown.json` (default: `/state/cooldown.json`) before taking any remediation action. The file is valid JSON, readable and writable using standard shell tools (`cat`, `jq`, `python3`). No custom parsers or binary formats are needed.
 
 - **Max 2 container restarts** per service per 4-hour window
 - **Max 1 full redeployment** (Ansible/Helm) per service per 24-hour window

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -19,6 +19,7 @@ services:
       - CLAUDEOPS_PR_ENABLED=${CLAUDEOPS_PR_ENABLED:-false}
     ports:
       - "8080:8080"
+    # Governing: SPEC-0007 REQ-3 — state directory backed by bind mount, persists across restarts/rebuilds
     volumes:
       - ./state:/state
       - ./results:/results

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -26,6 +26,8 @@ echo "  Tier: ${CLAUDEOPS_TIER}"
 echo "  Dry run: ${DRY_RUN}"
 echo ""
 
+# Governing: SPEC-0007 REQ-1 (state file at $CLAUDEOPS_STATE_DIR/cooldown.json),
+#            SPEC-0007 REQ-2 (initialize if missing, never overwrite existing)
 # Ensure state file exists
 if [ ! -f "${STATE_DIR}/cooldown.json" ]; then
     echo '{"services":{},"last_run":null,"last_daily_digest":null}' > "${STATE_DIR}/cooldown.json"

--- a/skills/cooldowns.md
+++ b/skills/cooldowns.md
@@ -1,6 +1,7 @@
+<!-- Governing: SPEC-0007 REQ-1 (state file location), REQ-10 (agent tooling), REQ-11 (human readability) -->
 # Skill: Cooldown Management
 
-Read the cooldown state file at `$CLAUDEOPS_STATE_DIR/cooldown.json` before taking any remediation action.
+Read the cooldown state file at `$CLAUDEOPS_STATE_DIR/cooldown.json` (default: `/state/cooldown.json`) before taking any remediation action. The file is valid JSON, readable and writable with `cat`, `jq`, or `python3` -- no custom parsers needed.
 
 ## Limits
 


### PR DESCRIPTION
Closes #310
Part of epic #215
Part of SPEC-0007

## Summary

Adds governing comments and clarifications for cooldown state file storage and initialization requirements:

- **REQ-1 (State File Location)**: `entrypoint.sh` already uses `$CLAUDEOPS_STATE_DIR/cooldown.json` with `/state` default. Added governing comment. Clarified default path in `CLAUDE.md` and `skills/cooldowns.md`.
- **REQ-2 (State File Initialization)**: `entrypoint.sh` already creates `{"services":{},"last_run":null,"last_daily_digest":null}` only if file is missing. Added governing comment.
- **REQ-3 (Persistent Volume Mount)**: `docker-compose.yaml` already mounts `./state:/state` as a bind mount. Added governing comment.
- **REQ-10 (Agent Tooling Compatibility)**: `jq` is installed in the Dockerfile. Added documentation in `CLAUDE.md` and `skills/cooldowns.md` noting the file is readable/writable with `cat`, `jq`, `python3`.
- **REQ-11 (Human Readability)**: State file is valid JSON. Added documentation noting no custom parsers or binary formats are needed.

## Test plan

- [x] `go vet ./...` passes
- [x] `go test ./... -count=1 -race` passes
- [ ] Verify `entrypoint.sh` init logic matches REQ-2 default structure
- [ ] Verify `docker-compose.yaml` state volume mount persists across restarts
- [ ] Verify governing comments are placed correctly