### PR TITLE
Restart & Redeployment Cooldown Limits (SPEC-0007 REQ-4/5)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -209,6 +209,7 @@ These Docker-level restrictions provide defense-in-depth that does not depend on
 ## Cooldown Rules
 
 <!-- Governing: SPEC-0003 REQ-9 (Cooldown as Secondary Safety Net) -->
+<!-- Governing: SPEC-0007 REQ-4 (restart limit), REQ-5 (redeployment limit) -->
 
 The cooldown system acts as a secondary safety net that limits the blast radius of repeated remediation actions, independent of the permission tier.
 

--- a/playbooks/redeploy-service.md
+++ b/playbooks/redeploy-service.md
@@ -1,4 +1,4 @@
-<!-- Governing: SPEC-0002 REQ-1 (markdown as sole instruction format), REQ-3 (Playbook Document Structure), REQ-8 (no build step), REQ-9 (self-documenting) -->
+<!-- Governing: SPEC-0002 REQ-1 (markdown as sole instruction format), SPEC-0007 REQ-5 (max 1 redeployment per service per 24-hour window), REQ-3 (Playbook Document Structure), REQ-8 (no build step), REQ-9 (self-documenting) -->
 # Playbook: Redeploy Service
 
 <!-- Governing: SPEC-0002 REQ-11 — Playbook Tier Gating, REQ-3 — Playbook Document Structure -->

--- a/playbooks/restart-container.md
+++ b/playbooks/restart-container.md
@@ -1,4 +1,4 @@
-<!-- Governing: SPEC-0002 REQ-1 (markdown as sole instruction format), REQ-3 (Playbook Document Structure), REQ-8 (no build step), REQ-9 (self-documenting) -->
+<!-- Governing: SPEC-0002 REQ-1 (markdown as sole instruction format), SPEC-0007 REQ-4 (max 2 restarts per service per 4-hour window), REQ-3 (Playbook Document Structure), REQ-8 (no build step), REQ-9 (self-documenting) -->
 # Playbook: Restart Container
 
 <!-- Governing: SPEC-0002 REQ-11 — Playbook Tier Gating, REQ-3 — Playbook Document Structure -->

--- a/prompts/tier2-investigate.md
+++ b/prompts/tier2-investigate.md
@@ -255,6 +255,7 @@ For each failed service, dig deeper:
 ## Step 3: Check Cooldown
 
 <!-- Governing: SPEC-0003 REQ-9 (Cooldown as Secondary Safety Net) -->
+<!-- Governing: SPEC-0007 REQ-4 (max 2 restarts per 4h), REQ-5 (max 1 redeployment per 24h) -->
 
 Read `/app/skills/cooldowns.md` for cooldown rules, then read `/state/cooldown.json` before any remediation. The cooldown system acts as a **secondary safety net** that limits the blast radius of repeated remediation, independent of the permission tier. If cooldown limit is exceeded, skip to Step 5 (Notify).
 

--- a/prompts/tier3-remediate.md
+++ b/prompts/tier3-remediate.md
@@ -252,6 +252,7 @@ With the full picture, determine the actual root cause:
 ## Step 3: Check Cooldown
 
 <!-- Governing: SPEC-0003 REQ-9 (Cooldown as Secondary Safety Net) -->
+<!-- Governing: SPEC-0007 REQ-4 (max 2 restarts per 4h), REQ-5 (max 1 redeployment per 24h) -->
 
 Read `/app/skills/cooldowns.md` for cooldown rules, then read `/state/cooldown.json`. The cooldown system acts as a **secondary safety net** that limits the blast radius of repeated remediation, independent of the permission tier. If cooldown limit is exceeded, skip to Step 5 (report as needs human attention).
 

--- a/skills/cooldowns.md
+++ b/skills/cooldowns.md
@@ -1,4 +1,4 @@
-<!-- Governing: SPEC-0007 REQ-1 (state file location), REQ-10 (agent tooling), REQ-11 (human readability) -->
+<!-- Governing: SPEC-0007 REQ-1 (state file location), REQ-4 (max 2 restarts per 4h), REQ-5 (max 1 redeployment per 24h), REQ-10 (agent tooling), REQ-11 (human readability) -->
 <!-- Governing: SPEC-0003 REQ-9 (Cooldown as Secondary Safety Net) -->
 
 # Skill: Cooldown Management


### PR DESCRIPTION
Closes #311
Part of SPEC-0007

## Summary

- Added SPEC-0007 governing comments to trace existing cooldown limit enforcement back to spec requirements
- **REQ-4 (Restart Cooldown)**: Max 2 container restarts per service per 4-hour window — enforced in `skills/cooldowns.md`, `playbooks/restart-container.md`, `prompts/tier2-investigate.md` Step 3, and `CLAUDE.md` Cooldown Rules
- **REQ-5 (Redeployment Cooldown)**: Max 1 full redeployment per service per 24-hour window — enforced in `skills/cooldowns.md`, `playbooks/redeploy-service.md`, `prompts/tier3-remediate.md` Step 3, and `CLAUDE.md` Cooldown Rules
- All requirements were already fully implemented; this PR adds traceability

## Test plan

- [ ] `go vet ./...` passes
- [ ] `go test ./... -count=1 -race` passes
- [ ] Verify `skills/cooldowns.md` documents both limits with per-tier rules
- [ ] Verify `playbooks/restart-container.md` prerequisites reference 2-per-4h limit
- [ ] Verify `playbooks/redeploy-service.md` prerequisites reference 1-per-24h limit
- [ ] Verify tier 2 and tier 3 prompts check cooldown before remediation

🤖 Generated with [Claude Code](https://claude.com/claude-code)