### PR TITLE
State Updates & Timestamps (SPEC-0007 REQ-7/8/9)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -219,7 +219,9 @@ Read the cooldown state file at `$CLAUDEOPS_STATE_DIR/cooldown.json` (default: `
 - **Max 1 full redeployment** (Ansible/Helm) per service per 24-hour sliding window
 - If the cooldown limit is exceeded: stop retrying, send a notification marked "needs human attention"
 - Reset counters when a service is confirmed healthy for 2 consecutive checks
-- Always update the state file after any remediation attempt or health check
+- Always update the state file after any remediation attempt or health check <!-- Governing: SPEC-0007 REQ-7 -->
+- Update `last_run` with the current UTC timestamp (ISO 8601) at the end of every agent loop iteration <!-- Governing: SPEC-0007 REQ-8 -->
+- Update `last_daily_digest` when a daily digest notification is sent; send a digest when this field is null or more than 24 hours ago <!-- Governing: SPEC-0007 REQ-9 -->
 - Only one agent container may write to the state file at a time (single-writer model; see `skills/cooldowns.md`)
 
 ## Notifications via Apprise

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -37,7 +37,10 @@ echo ""
 
 # Governing: SPEC-0007 REQ-1 (state file at $CLAUDEOPS_STATE_DIR/cooldown.json),
 #            SPEC-0007 REQ-2 (initialize if missing, never overwrite existing)
-# Ensure state file exists
+# Governing: SPEC-0007 REQ-8 (last_run tracking), REQ-9 (daily digest tracking)
+# Initialize cooldown state file with last_run and last_daily_digest fields.
+# The agent updates last_run at the end of every iteration (REQ-8) and
+# last_daily_digest when a daily digest is sent (REQ-9).
 if [ ! -f "${STATE_DIR}/cooldown.json" ]; then
     echo '{"services":{},"last_run":null,"last_daily_digest":null}' > "${STATE_DIR}/cooldown.json"
 fi

--- a/prompts/tier1-observe.md
+++ b/prompts/tier1-observe.md
@@ -308,8 +308,9 @@ Run checks ONLY against the hosts and services discovered from repos. **Never ch
 ## Step 4: Read Cooldown State
 
 <!-- Governing: SPEC-0003 REQ-9 (Cooldown as Secondary Safety Net) -->
+<!-- Governing: SPEC-0007 REQ-8, REQ-9 — Last Run and Daily Digest Tracking -->
 
-Read `/app/skills/cooldowns.md` for cooldown rules, then read `/state/cooldown.json`. Note any services in cooldown. The cooldown system acts as a **secondary safety net** that limits the blast radius of repeated remediation, independent of the permission tier.
+Read `/app/skills/cooldowns.md` for cooldown rules, then read `/state/cooldown.json`. Note any services in cooldown. Also check the `last_daily_digest` field to determine if a daily digest is due (null or more than 24 hours ago). The cooldown system acts as a **secondary safety net** that limits the blast radius of repeated remediation, independent of the permission tier.
 
 ## Step 5: Evaluate Results
 
@@ -356,8 +357,10 @@ Tier 1 supports two notification event categories:
 When `$CLAUDEOPS_APPRISE_URLS` is empty or unset, skip all notifications silently (no errors). When set, it may contain multiple comma-separated Apprise URLs — the same notification is delivered to ALL configured targets simultaneously.
 
 ### All healthy
-- Update `last_run` in the cooldown state file
-- If a daily digest is due (check `last_daily_digest`), compose and send one via Apprise (if configured):
+<!-- Governing: SPEC-0007 REQ-8 — Last Run Tracking -->
+- Update `last_run` in the cooldown state file with the current UTC timestamp in ISO 8601 format (e.g., `2025-06-15T10:30:00Z`). This MUST happen at the end of every iteration, regardless of outcome.
+<!-- Governing: SPEC-0007 REQ-9 — Daily Digest Tracking -->
+- If a daily digest is due (check `last_daily_digest` — send if null or more than 24 hours ago), compose and send one via Apprise (if configured). After sending, update `last_daily_digest` with the current UTC timestamp.
 
 <!-- Governing: SPEC-0004 REQ-3 — CLI-Based Invocation -->
 

--- a/prompts/tier2-investigate.md
+++ b/prompts/tier2-investigate.md
@@ -293,8 +293,10 @@ Apply the appropriate remediation from `/app/playbooks/` and any repo-contribute
 2. `chown`/`chmod` the affected paths
 3. Restart the service if needed
 
-After each remediation:
-- Update the cooldown state file
+<!-- Governing: SPEC-0007 REQ-7 — State Update After Remediation -->
+
+After each remediation attempt (whether successful or not):
+- Update the cooldown state file immediately: increment the restart or redeployment count, record the timestamp (ISO 8601 UTC), and note the outcome (success/failure)
 - Verify the fix by re-checking the service
 
 <!-- Governing: SPEC-0018 REQ-9 "Permission Tier Integration" — Tier 2 permitted to create PRs for non-structural changes -->

--- a/prompts/tier3-remediate.md
+++ b/prompts/tier3-remediate.md
@@ -273,6 +273,9 @@ Do NOT probe for or use alternative remote access methods (Docker TCP API on por
 
 <!-- Governing: SPEC-0002 REQ-10 — Agent Reads Checks at Runtime -->
 <!-- Governing: SPEC-0002 REQ-11 — Playbook Tier Gating -->
+<!-- Governing: SPEC-0007 REQ-7 — State Update After Remediation -->
+
+**After every remediation attempt** (whether successful or not), immediately update the cooldown state file: increment the restart or redeployment count, record the timestamp (ISO 8601 UTC), and note the outcome (success/failure). This applies to all remediation types below.
 
 Read the applicable playbook files from `/app/playbooks/` and `.claude-ops/playbooks/` from mounted repos at runtime. Do NOT rely on cached or pre-compiled instructions — always re-read playbook files before executing them. **Before executing any playbook, check its minimum tier requirement.** As Tier 3, you may execute all playbooks regardless of their minimum tier.
 


### PR DESCRIPTION
Closes #313
Part of epic #215
Part of SPEC-0007

## Summary

Ensures cooldown state updates and timestamp tracking comply with SPEC-0007:

- **REQ-7 (State Update After Remediation)**: Added `<!-- Governing: SPEC-0007 REQ-7 -->` to tier2 and tier3 prompts with explicit instructions to update the cooldown state file immediately after every remediation attempt (successful or not), recording the action type, ISO 8601 UTC timestamp, and outcome.

- **REQ-8 (Last Run Tracking)**: Added `# Governing: SPEC-0007 REQ-8` to entrypoint.sh state initialization and `<!-- Governing: SPEC-0007 REQ-8 -->` to tier1 prompt. The `last_run` field MUST be updated with current UTC timestamp at the end of every agent loop iteration.

- **REQ-9 (Daily Digest Tracking)**: Added `# Governing: SPEC-0007 REQ-9` to entrypoint.sh and `<!-- Governing: SPEC-0007 REQ-9 -->` to tier1 prompt. The `last_daily_digest` field is checked (null or >24h ago) to determine if a digest should be sent, and updated after sending.

## Files Changed

- `CLAUDE.md` — Added last_run and last_daily_digest rules to cooldown section
- `entrypoint.sh` — Governing comments on state file initialization
- `prompts/tier1-observe.md` — REQ-8/9 governing comments on last_run update and daily digest check
- `prompts/tier2-investigate.md` — REQ-7 governing comment on post-remediation state update
- `prompts/tier3-remediate.md` — REQ-7 governing comment on post-remediation state update

## Test Plan

- [x] `go vet ./...` passes
- [x] `go test ./... -count=1 -race` passes
- [ ] Verify tier1 prompt updates last_run and checks last_daily_digest
- [ ] Verify tier2/tier3 prompts update state after every remediation attempt