### PR TITLE
SQLite Storage & History governing comments (SPEC-0008 REQ-8/9)

### DIFF
--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -12,6 +12,7 @@ import (
 )
 
 // DB wraps a sql.DB connection to the SQLite database.
+// Governing: SPEC-0008 REQ-8 — SQLite State Storage (pure-Go driver via modernc.org/sqlite)
 type DB struct {
 	conn *sql.DB
 }
@@ -39,6 +40,7 @@ type Session struct {
 }
 
 // HealthCheck represents a parsed health check result.
+// Governing: SPEC-0008 REQ-9 — Health Check History (service, check_type, status, timestamp, response_time, error)
 type HealthCheck struct {
 	ID             int64
 	SessionID      *int64
@@ -87,6 +89,7 @@ type CooldownAction struct {
 }
 
 // Open creates a new DB connection and runs all pending migrations.
+// Governing: SPEC-0008 REQ-8 — SQLite State Storage (database init and schema migration on startup)
 // Governing: SPEC-0022 REQ "Goose Provider API Integration"
 func Open(path string) (*DB, error) {
 	conn, err := sql.Open("sqlite", path+"?_pragma=journal_mode(wal)&_pragma=busy_timeout(5000)")
@@ -232,6 +235,7 @@ func (d *DB) ListSessions(limit, offset int) ([]Session, error) {
 }
 
 // --- Health Check Methods ---
+// Governing: SPEC-0008 REQ-9 — Health Check History (store and query health check results)
 
 // InsertHealthCheck stores a health check result.
 func (d *DB) InsertHealthCheck(h *HealthCheck) (int64, error) {
@@ -321,6 +325,7 @@ func (d *DB) ListEvents(limit, offset int, level, service *string) ([]Event, err
 }
 
 // --- Cooldown Methods ---
+// Governing: SPEC-0008 REQ-8 — SQLite State Storage (cooldown enforcement via SQLite replaces cooldown.json)
 
 // CheckCooldown returns the count of actions of the given type for a service
 // within the specified window.

--- a/internal/db/embed.go
+++ b/internal/db/embed.go
@@ -2,6 +2,7 @@ package db
 
 import "embed"
 
+// Governing: SPEC-0008 REQ-8 — SQLite State Storage (schema migration on startup)
 // Governing: SPEC-0022 REQ "Embedded Migrations via go:embed"
 // MigrationFS embeds all SQL migration files into the compiled binary.
 // At runtime, no migration files need to exist on disk.

--- a/internal/db/migrations/00001_initial_schema.sql
+++ b/internal/db/migrations/00001_initial_schema.sql
@@ -1,4 +1,6 @@
 -- +goose Up
+-- Governing: SPEC-0008 REQ-8 — SQLite State Storage (sessions, cooldown_actions, config tables)
+-- Governing: SPEC-0008 REQ-9 — Health Check History (health_checks table with queryable history)
 CREATE TABLE sessions (
     id INTEGER PRIMARY KEY AUTOINCREMENT,
     tier INTEGER NOT NULL,


### PR DESCRIPTION
## Summary
- Adds SPEC-0008 governing comments to trace existing `internal/db/` implementation back to spec requirements
- REQ-8 (SQLite State Storage): `DB` struct, `Open()`, cooldown methods, `embed.go`, migration schema
- REQ-9 (Health Check History): `HealthCheck` struct, health check query methods, migration schema

## Verification
- Confirmed `internal/db/` already has migrations, sessions/health_checks/cooldown_actions tables
- All existing tests pass (`go test ./... -count=1 -race`)
- `go vet ./...` clean

Closes #319 / Part of SPEC-0008

## Test plan
- [x] `go vet ./...` passes
- [x] `go test ./... -count=1 -race` passes
- [x] Governing comments reference correct SPEC-0008 REQ numbers

🤖 Generated with [Claude Code](https://claude.com/claude-code)