### PR TITLE
Session Management & CLI Invocation (SPEC-0008 REQ-5, REQ-11)

### DIFF
--- a/cmd/claudeops/main.go
+++ b/cmd/claudeops/main.go
@@ -137,6 +137,10 @@ func run(cmd *cobra.Command, args []string) error {
 	sseHub := hub.New()
 
 	// Create session manager with MCP merging as pre-session hook.
+	// Governing: SPEC-0008 REQ-5 "Claude Code CLI Session Management"
+	// — session manager handles scheduling, subprocess creation, and tier tracking.
+	// Governing: SPEC-0008 REQ-11 "MCP Configuration Merging"
+	// — PreSessionHook merges .claude-ops/mcp.json from repos before each session.
 	mgr := session.New(&cfg, database, sseHub, &session.CLIRunner{})
 	mgr.PreSessionHook = func() error {
 		fmt.Println("Merging MCP configurations...")

--- a/internal/mcp/merge.go
+++ b/internal/mcp/merge.go
@@ -19,6 +19,10 @@ import (
 // Repo configs are discovered at {reposDir}/*/.claude-ops/mcp.json. Each
 // repo's "mcpServers" entries are merged into the baseline. On name collision,
 // the repo config wins (overrides the baseline).
+//
+// Governing: SPEC-0008 REQ-11 "MCP Configuration Merging"
+// — replicates entrypoint.sh merge behavior: discovers .claude-ops/mcp.json
+// from mounted repos, merges into baseline, repo configs override on collision.
 func MergeConfigs(mcpConfigPath, reposDir string) error {
 	// If the MCP config doesn't exist, there's nothing to merge into. This is
 	// normal when running locally outside Docker.

--- a/internal/session/runner.go
+++ b/internal/session/runner.go
@@ -10,6 +10,8 @@ import (
 
 // ProcessRunner abstracts the spawning of a Claude CLI subprocess so that
 // tests can substitute a mock implementation.
+// Governing: SPEC-0008 REQ-5 "CLI subprocess creation"
+// — uses os/exec.Command to invoke the claude CLI binary.
 type ProcessRunner interface {
 	Start(ctx context.Context, model string, promptContent string, allowedTools string, appendSystemPrompt string) (stdout io.ReadCloser, wait func() error, err error)
 }
@@ -20,6 +22,9 @@ type CLIRunner struct{}
 // Start builds and starts a claude CLI process with stream-json output.
 // It returns a reader for stdout, a wait function that blocks until the
 // process exits, and any startup error.
+// Governing: SPEC-0008 REQ-5 "CLI subprocess creation"
+// — passes model, prompt content, allowed tools, and system prompt arguments
+// matching the entrypoint.sh invocation pattern via os/exec.Command.
 func (r *CLIRunner) Start(ctx context.Context, model string, promptContent string, allowedTools string, appendSystemPrompt string) (io.ReadCloser, func() error, error) {
 	args := []string{
 		"--model", model,


### PR DESCRIPTION
## Summary

- Adds governing comments tracing implementation back to SPEC-0008 REQ-5 (Claude Code CLI Session Management) and REQ-11 (MCP Configuration Merging)
- Annotates session scheduler, concurrent session guard, CLI subprocess creation, MCP merge logic, and PreSessionHook wiring in `cmd/claudeops/main.go`

## Files Changed

- `internal/session/manager.go` — REQ-5 governing comments on `Manager` struct, `Run()` loop, `runTier()` concurrent session guard, PreSessionHook (REQ-11), and subprocess start
- `internal/session/runner.go` — REQ-5 governing comments on `ProcessRunner` interface and `CLIRunner.Start()`
- `internal/mcp/merge.go` — REQ-11 governing comment on `MergeConfigs()`
- `cmd/claudeops/main.go` — REQ-5 and REQ-11 governing comments on session manager + PreSessionHook wiring

## Test plan

- [x] `go vet ./...` passes
- [x] `go test ./... -count=1 -race` passes

Closes #317
Part of epic #3
Part of SPEC-0008

🤖 Generated with [Claude Code](https://claude.com/claude-code)