### PR TITLE
Add governing comments for frontend stack (SPEC-0008 REQ-3/4/14)

### DIFF
--- a/internal/web/handlers.go
+++ b/internal/web/handlers.go
@@ -264,6 +264,7 @@ func (s *Server) handleSession(w http.ResponseWriter, r *http.Request) {
 }
 
 // handleSessionStream opens an SSE connection for a running session.
+// Governing: SPEC-0008 REQ-3 — HTMX-Based Interactivity (hx-ext="sse" for real-time streaming)
 func (s *Server) handleSessionStream(w http.ResponseWriter, r *http.Request) {
 	idStr := r.PathValue("id")
 	id, err := strconv.Atoi(idStr)
@@ -538,6 +539,7 @@ func (s *Server) handleTriggerSession(w http.ResponseWriter, r *http.Request) {
 }
 
 // handleConfigPost processes configuration form submissions.
+// Governing: SPEC-0008 REQ-3 — HTMX-Based Interactivity (hx-post form submission with hx-swap)
 func (s *Server) handleConfigPost(w http.ResponseWriter, r *http.Request) {
 	if err := r.ParseForm(); err != nil {
 		http.Error(w, "bad form data", http.StatusBadRequest)

--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -31,6 +31,8 @@ var memoryBadgeRe = regexp.MustCompile(`\[MEMORY:([a-z]+)(?::([a-zA-Z0-9_-]+))?\
 // action is "restart" or "redeployment", service is required, result is "success" or "failure".
 var cooldownBadgeRe = regexp.MustCompile(`\[COOLDOWN:(restart|redeployment):([a-zA-Z0-9_-]+)\]\s*(success|failure)\s*[—–-]\s*([^\[<]+)`)
 
+// Governing: SPEC-0008 REQ-14 — Static Asset Embedding (templates embedded via go:embed)
+
 //go:embed templates/*.html
 var templateFS embed.FS
 
@@ -307,6 +309,7 @@ func (s *Server) parseTemplates() {
 	)
 }
 
+// Governing: SPEC-0008 REQ-14 — Static Asset Embedding (static files served from embed.FS)
 func (s *Server) registerRoutes() {
 	staticSub, _ := fs.Sub(staticFS, "static")
 	s.mux.Handle("GET /static/", http.StripPrefix("/static/", http.FileServer(http.FS(staticSub))))
@@ -349,6 +352,7 @@ func (s *Server) registerRoutes() {
 
 // render executes a template. If HX-Request header is set, render just the
 // content block; otherwise render the full layout wrapping the content.
+// Governing: SPEC-0008 REQ-3 — HTMX-Based Interactivity (partial rendering for HX-Request)
 func (s *Server) render(w http.ResponseWriter, r *http.Request, name string, data any) {
 	w.Header().Set("Content-Type", "text/html; charset=utf-8")
 

--- a/internal/web/static/style.css
+++ b/internal/web/static/style.css
@@ -1,6 +1,7 @@
 /* Claude Ops Dashboard Theme
    Clean, minimal, robotic. Dieter Rams energy.
-   Warm off-white, charcoal text, burnt orange accents. */
+   Warm off-white, charcoal text, burnt orange accents.
+   Governing: SPEC-0008 REQ-4 — DaisyUI/TailwindCSS Styling (custom theme extending DaisyUI) */
 
 /* ---- Color tokens ---- */
 :root {

--- a/internal/web/templates/layout.html
+++ b/internal/web/templates/layout.html
@@ -4,9 +4,11 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>Claude Ops{{if eq .Page "sessions.html"}} &mdash; Sessions{{else if eq .Page "session.html"}} &mdash; Session{{else if eq .Page "events.html"}} &mdash; Events{{else if eq .Page "memories.html"}} &mdash; Memories{{else if eq .Page "cooldowns.html"}} &mdash; Cooldowns{{else if eq .Page "config.html"}} &mdash; Config{{end}}</title>
+    {{/* Governing: SPEC-0008 REQ-4 — DaisyUI/TailwindCSS loaded via CDN, no build step required */}}
     <script src="https://cdn.tailwindcss.com"></script>
     <link href="https://cdn.jsdelivr.net/npm/daisyui@4.12.23/dist/full.min.css" rel="stylesheet">
     <link href="/static/style.css" rel="stylesheet">
+    {{/* Governing: SPEC-0008 REQ-3 — HTMX loaded via CDN, no JS build toolchain required */}}
     <script src="https://unpkg.com/htmx.org@2.0.4"></script>
     <script src="https://unpkg.com/htmx-ext-sse@2.2.2/sse.js"></script>
 </head>


### PR DESCRIPTION
## Summary

- Adds `SPEC-0008 REQ-3` governing comments for HTMX-based interactivity: CDN loading in `layout.html`, SSE streaming handler, config form submission handler, and partial rendering in `render()` method
- Adds `SPEC-0008 REQ-4` governing comments for DaisyUI/TailwindCSS styling: CDN loading in `layout.html` and custom theme in `style.css`
- Adds `SPEC-0008 REQ-14` governing comments for static asset embedding: `go:embed` directives in `server.go` and `registerRoutes()` static file serving

Closes #316
Part of epic #3
Part of SPEC-0008

## Test plan

- [x] `go vet ./...` passes
- [x] `go test ./... -count=1 -race` passes
- [ ] Verify HTMX attributes (`hx-get`, `hx-post`, `hx-ext="sse"`) present in templates
- [ ] Verify DaisyUI CDN and TailwindCSS CDN loaded in layout
- [ ] Verify `//go:embed` directives embed templates and static assets

🤖 Generated with [Claude Code](https://claude.com/claude-code)