### PR TITLE
Add SPEC-0008 governing comments for subprocess lifecycle

### DIFF
--- a/cmd/claudeops/main.go
+++ b/cmd/claudeops/main.go
@@ -161,6 +161,7 @@ func run(cmd *cobra.Command, args []string) error {
 		}
 	}()
 
+	// Governing: SPEC-0008 REQ-13 — graceful shutdown: forward signals, cancel context, drain sessions.
 	// Set up signal handling.
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -177,7 +178,7 @@ func run(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("session manager: %w", err)
 	}
 
-	// Gracefully shut down web server.
+	// Governing: SPEC-0008 REQ-13 — graceful web server shutdown with timeout.
 	shutdownCtx, shutdownCancel := context.WithTimeout(context.Background(), 5*1e9)
 	defer shutdownCancel()
 	if err := webServer.Shutdown(shutdownCtx); err != nil {

--- a/internal/hub/hub.go
+++ b/internal/hub/hub.go
@@ -42,6 +42,7 @@ func (s *session) append(line string) {
 // Hub fans out session output lines to multiple SSE subscribers.
 // It buffers the last defaultBufferCap lines per session so late-joining
 // clients receive catchup output before live streaming.
+// Governing: SPEC-0008 REQ-6 — real-time session output streaming via SSE fan-out.
 type Hub struct {
 	mu       sync.Mutex
 	sessions map[int]*session

--- a/internal/session/runner.go
+++ b/internal/session/runner.go
@@ -10,8 +10,8 @@ import (
 
 // ProcessRunner abstracts the spawning of a Claude CLI subprocess so that
 // tests can substitute a mock implementation.
-// Governing: SPEC-0008 REQ-5 "CLI subprocess creation"
-// — uses os/exec.Command to invoke the claude CLI binary.
+// Governing: SPEC-0008 REQ-5 "CLI subprocess creation" — uses os/exec.Command to invoke the claude CLI binary.
+// Governing: SPEC-0008 REQ-7 — subprocess lifecycle management (startup, completion, crash handling).
 type ProcessRunner interface {
 	Start(ctx context.Context, model string, promptContent string, allowedTools string, appendSystemPrompt string) (stdout io.ReadCloser, wait func() error, err error)
 }
@@ -39,7 +39,7 @@ func (r *CLIRunner) Start(ctx context.Context, model string, promptContent strin
 	}
 
 	cmd := exec.Command("claude", args...)
-	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true} // Governing: SPEC-0008 REQ-7 — process group isolation for signal forwarding.
 	cmd.Stderr = os.Stderr
 
 	stdoutPipe, err := cmd.StdoutPipe()


### PR DESCRIPTION
## Summary

- Adds `// Governing: SPEC-0008 REQ-6` to `internal/hub/hub.go` (SSE fan-out streaming)
- Adds `// Governing: SPEC-0008 REQ-7` to `internal/session/runner.go` (subprocess spawning, process group isolation) and `internal/session/manager.go` (full lifecycle: start, stream, wait, exit code, crash handling)
- Adds `// Governing: SPEC-0008 REQ-13` to `cmd/claudeops/main.go` (signal handling, graceful shutdown with timeout)

## Test plan

- [x] `go vet ./...` passes
- [x] `go test ./... -count=1 -race` passes
- [ ] Verify governing comments are correctly placed next to the relevant implementation code

Closes #318 / Part of SPEC-0008