### PR TITLE
Add SPEC-0008 governing comments for binary entrypoint and web server

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,4 @@
+# Governing: SPEC-0008 REQ-1 (Single Binary Entrypoint — static binary replaces entrypoint.sh)
 # Build stage: compile Go binary
 FROM golang:1.24-alpine AS builder
 

--- a/cmd/claudeops/main.go
+++ b/cmd/claudeops/main.go
@@ -23,6 +23,7 @@ import (
 	"github.com/joestump/claude-ops/internal/web"
 )
 
+// Governing: SPEC-0008 REQ-1 (Single Binary Entrypoint — compiles to static binary, replaces entrypoint.sh)
 func main() {
 	rootCmd := &cobra.Command{
 		Use:   "claudeops",
@@ -146,6 +147,7 @@ func run(cmd *cobra.Command, args []string) error {
 	// Create git provider registry.
 	registry := gitprovider.NewRegistry()
 
+	// Governing: SPEC-0008 REQ-2 (Web Server — HTTP on configurable port, default 8080)
 	// Create and start web server (needs mgr for ad-hoc session triggers).
 	webServer := web.New(&cfg, sseHub, database, mgr, registry)
 	go func() {

--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -48,6 +48,7 @@ type SessionTrigger interface {
 	IsRunning() bool
 }
 
+// Governing: SPEC-0008 REQ-2 (Web Server — HTTP on configurable port, default 8080)
 // Server is the HTTP server for the Claude Ops dashboard.
 type Server struct {
 	cfg      *config.Config


### PR DESCRIPTION
## Summary
- Verifies `cmd/claudeops/main.go` implements SPEC-0008 REQ-1 (single static binary entrypoint via `CGO_ENABLED=0` build) and REQ-2 (HTTP web server on configurable port, default 8080)
- Adds `// Governing: SPEC-0008 REQ-1` comment to `main()` function in `cmd/claudeops/main.go`
- Adds `// Governing: SPEC-0008 REQ-2` comments to web server creation in `cmd/claudeops/main.go` and `Server` struct in `internal/web/server.go`
- Adds `# Governing: SPEC-0008 REQ-1` comment to `Dockerfile` build stage

Closes #315 / Part of SPEC-0008

## Test plan
- [x] `go vet ./...` passes
- [x] `go test ./... -count=1 -race` passes
- [ ] Verify governing comments are present in the correct locations

🤖 Generated with [Claude Code](https://claude.com/claude-code)