### PR TITLE
Add SPEC-0008 governing comments for dashboard pages and config

### DIFF
--- a/cmd/claudeops/main.go
+++ b/cmd/claudeops/main.go
@@ -83,6 +83,7 @@ func main() {
 	bindFlag("pr_enabled", "pr-enabled")
 	bindFlag("summary_model", "summary-model")
 
+	// Governing: SPEC-0008 REQ-12 — environment variable compatibility (CLAUDEOPS_* prefix).
 	// Bind CLAUDEOPS_* environment variables. AutomaticEnv with the prefix
 	// maps CLAUDEOPS_INTERVAL -> "interval", CLAUDEOPS_TIER1_MODEL -> "tier1_model", etc.
 	viper.SetEnvPrefix("CLAUDEOPS")

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -6,6 +6,7 @@ import "github.com/spf13/viper"
 var Version = "dev"
 
 // Config holds all runtime configuration for Claude Ops.
+// Governing: SPEC-0008 REQ-12 — environment variable compatibility (CLAUDEOPS_* env vars via viper).
 type Config struct {
 	Interval      int
 	Prompt        string

--- a/internal/web/handlers.go
+++ b/internal/web/handlers.go
@@ -16,6 +16,7 @@ import (
 )
 
 // handleIndex renders the overview dashboard.
+// Governing: SPEC-0008 REQ-10 — overview/home page: service summary and last check time.
 // Governing: SPEC-0021 REQ "TL;DR Page Rendering"
 // Governing: SPEC-0013 "Real-Time Overview" — serves polling endpoint for HTMX auto-refresh
 func (s *Server) handleIndex(w http.ResponseWriter, r *http.Request) {
@@ -151,6 +152,7 @@ func (s *Server) handleSessions(w http.ResponseWriter, r *http.Request) {
 }
 
 // handleSession renders a single session detail view.
+// Governing: SPEC-0008 REQ-10 — session view page: streaming output, tier level, and target service.
 func (s *Server) handleSession(w http.ResponseWriter, r *http.Request) {
 	idStr := r.PathValue("id")
 	id, err := strconv.ParseInt(idStr, 10, 64)
@@ -268,6 +270,7 @@ func (s *Server) handleSession(w http.ResponseWriter, r *http.Request) {
 
 // handleSessionStream opens an SSE connection for a running session.
 // Governing: SPEC-0008 REQ-3 — HTMX-Based Interactivity (hx-ext="sse" for real-time streaming)
+// Governing: SPEC-0008 REQ-10 — session view real-time streaming via SSE.
 func (s *Server) handleSessionStream(w http.ResponseWriter, r *http.Request) {
 	idStr := r.PathValue("id")
 	id, err := strconv.Atoi(idStr)
@@ -332,6 +335,7 @@ func (s *Server) handleEvents(w http.ResponseWriter, r *http.Request) {
 }
 
 // handleCooldowns renders the cooldown state.
+// Governing: SPEC-0008 REQ-10 — cooldown state page: per-service action counts and window expiry.
 func (s *Server) handleCooldowns(w http.ResponseWriter, r *http.Request) {
 	cooldowns, err := s.db.ListRecentCooldowns(24 * time.Hour)
 	if err != nil {
@@ -489,6 +493,7 @@ func (s *Server) handleMemoryDelete(w http.ResponseWriter, r *http.Request) {
 }
 
 // handleConfigGet renders the configuration form.
+// Governing: SPEC-0008 REQ-10 — configuration page: runtime parameter display and modification.
 func (s *Server) handleConfigGet(w http.ResponseWriter, r *http.Request) {
 	data := struct {
 		Interval              int
@@ -548,6 +553,7 @@ func (s *Server) handleTriggerSession(w http.ResponseWriter, r *http.Request) {
 
 // handleConfigPost processes configuration form submissions.
 // Governing: SPEC-0008 REQ-3 — HTMX-Based Interactivity (hx-post form submission with hx-swap)
+// Governing: SPEC-0008 REQ-10 — configuration changes take effect without container restart.
 func (s *Server) handleConfigPost(w http.ResponseWriter, r *http.Request) {
 	if err := r.ParseForm(); err != nil {
 		http.Error(w, "bad form data", http.StatusBadRequest)

--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -311,6 +311,7 @@ func (s *Server) parseTemplates() {
 }
 
 // Governing: SPEC-0008 REQ-14 — Static Asset Embedding (static files served from embed.FS)
+// Governing: SPEC-0008 REQ-10 — dashboard pages: overview, session view, cooldowns, config, events, memories.
 func (s *Server) registerRoutes() {
 	staticSub, _ := fs.Sub(staticFS, "static")
 	s.mux.Handle("GET /static/", http.StripPrefix("/static/", http.FileServer(http.FS(staticSub))))


### PR DESCRIPTION
## Summary

- Adds `// Governing: SPEC-0008 REQ-10` to route registration (`server.go`) and all dashboard page handlers in `handlers.go`: overview (`handleIndex`), session view (`handleSession`, `handleSessionStream`), cooldowns (`handleCooldowns`), and config (`handleConfigGet`, `handleConfigPost`)
- Adds `// Governing: SPEC-0008 REQ-12` to `internal/config/config.go` (Config struct) and `cmd/claudeops/main.go` (viper env var binding with `CLAUDEOPS_*` prefix)
- Notes: REQ-15 (basic auth, CSRF) has no implementation yet — no governing comments added for it

## Test plan

- [x] `go vet ./...` passes
- [x] `go test ./... -count=1 -race` passes
- [ ] Verify governing comments are correctly placed next to the relevant implementation code

Closes #320 / Part of SPEC-0008