### PR TITLE
Add SPEC-0010 governing comments for CLI installation and subprocess invocation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,6 +28,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 # Apprise for notifications (supports 80+ services)
 RUN pip3 install --break-system-packages --retries 3 --timeout 120 apprise
 
+# Governing: SPEC-0010 REQ-1 (CLI Installation via npm — globally installed, available on PATH)
 # Claude Code CLI
 RUN npm install -g @anthropic-ai/claude-code
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -86,6 +86,7 @@ while true; do
         ENV_CONTEXT="${ENV_CONTEXT} CLAUDEOPS_APPRISE_URLS=${CLAUDEOPS_APPRISE_URLS}"
     fi
 
+    # Governing: SPEC-0010 REQ-2 (Subprocess Invocation from Bash — CLI flags for all config, non-interactive, piped output)
     # Run Claude with tier 1 prompt
     claude \
         --model "${MODEL}" \


### PR DESCRIPTION
## Summary
- Verifies `Dockerfile` implements SPEC-0010 REQ-1 (CLI installed globally via `npm install -g @anthropic-ai/claude-code`, available on PATH)
- Verifies `entrypoint.sh` implements SPEC-0010 REQ-2 (subprocess invocation with CLI flags for model, prompt, tool filtering, system prompt injection, piped through `tee`, `|| true` for error handling)
- Adds `# Governing: SPEC-0010 REQ-1` comment to Dockerfile npm install line
- Adds `# Governing: SPEC-0010 REQ-2` comment to entrypoint.sh claude invocation

Closes #325
Part of epic #141
Part of SPEC-0010

## Test plan
- [x] `go vet ./...` passes
- [x] `go build ./...` compiles successfully
- [x] `go test ./... -count=1 -race` passes
- [ ] Verify governing comments are present in the correct locations

🤖 Generated with [Claude Code](https://claude.com/claude-code)