### PR TITLE
Context Injection & Output Mode governing comments (SPEC-0010 REQ-6/7)

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -84,6 +84,7 @@ while true; do
     echo "Merging MCP configurations..."
     merge_mcp_configs
 
+    # Governing: SPEC-0010 REQ-6 — Runtime Context Injection via --append-system-prompt
     # Build environment context for Claude
     ENV_CONTEXT="CLAUDEOPS_TIER=${CLAUDEOPS_TIER}"
     ENV_CONTEXT="${ENV_CONTEXT} CLAUDEOPS_DRY_RUN=${DRY_RUN}"
@@ -97,7 +98,8 @@ while true; do
 
     # Governing: SPEC-0004 REQ-1 (single env var config),
     #            SPEC-0004 REQ-2 (graceful degradation — only pass when set),
-    #            SPEC-0004 REQ-4 (env var passthrough to agent context)
+    #            SPEC-0004 REQ-4 (env var passthrough to agent context),
+    #            SPEC-0010 REQ-6 — Apprise URLs conditionally included
     # Pass Apprise URLs if configured; skip silently when unset (REQ-2).
     if [ -n "${CLAUDEOPS_APPRISE_URLS:-}" ]; then
         ENV_CONTEXT="${ENV_CONTEXT} CLAUDEOPS_APPRISE_URLS=${CLAUDEOPS_APPRISE_URLS}"
@@ -106,6 +108,8 @@ while true; do
     # Governing: SPEC-0003 REQ-6 (--allowedTools hard boundary),
     #            SPEC-0003 REQ-11 (prompt read at runtime — changes take effect next cycle),
     #            SPEC-0010 REQ-2 (Subprocess Invocation from Bash — CLI flags for all config, non-interactive, piped output)
+    # Governing: SPEC-0010 REQ-7 — Non-Interactive Output via -p (--print) piped through tee
+    # Governing: SPEC-0010 REQ-6 — --append-system-prompt injects ENV_CONTEXT at runtime
     # Run Claude with tier 1 prompt
     # Governing: SPEC-0010 REQ-3 (--model), REQ-4 (--prompt-file)
     # Governing: SPEC-0010 REQ-5 — --allowedTools and --disallowedTools enforce


### PR DESCRIPTION
## Summary
- Adds SPEC-0010 governing comments to `entrypoint.sh` tracing implementation back to spec requirements
- REQ-6 (Runtime Context Injection): `ENV_CONTEXT` assembly block and `--append-system-prompt` flag, including conditional Apprise URL inclusion
- REQ-7 (Non-Interactive Output): `-p` (print mode) flag with `tee` output capture for logging and stdout

## Verification
- Confirmed `entrypoint.sh` already implements REQ-6 (env context built as key=value string, injected via `--append-system-prompt`, Apprise URLs conditionally included)
- Confirmed `entrypoint.sh` already implements REQ-7 (`-p` flag for non-interactive output, `2>&1 | tee -a` for log capture, `|| true` for error resilience)
- All existing tests pass (`go test ./... -count=1 -race`)
- `go vet ./...` clean

Closes #328
Part of epic #141
Part of SPEC-0010

## Test plan
- [x] `go vet ./...` passes
- [x] `go test ./... -count=1 -race` passes
- [x] Governing comments reference correct SPEC-0010 REQ numbers
- [x] `entrypoint.sh` remains syntactically valid (comments only, no behavior change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)