### PR TITLE
Add SPEC-0010 governing comments for MCP, subagent, error handling, zero-code

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -48,6 +48,7 @@ If either step fails, fix the issues before pushing. No exceptions.
 
 Use the `/release` skill (`.claude/skills/release.md`) to create tagged releases. Releases are created with `gh release create` — never through the GitHub UI. The skill handles version bumping, release note generation, and pre-flight checks.
 
+<!-- Governing: SPEC-0010 REQ-11 (Zero Application Code Constraint — no src/, no compiled artifacts, CLI-provided features only) -->
 ## Architecture
 
 This is not a traditional codebase — there is no application code to compile or test. Claude Ops is an **AI agent runbook**: markdown documents that the Claude Code CLI reads and executes at runtime.
@@ -215,6 +216,7 @@ apprise -t "Title" -b "Message body" "$CLAUDEOPS_APPRISE_URLS"
 - **Tier 2** MUST send auto-remediation reports after successful remediations. MUST send human attention alerts when remediation fails or cooldown limits are exceeded.
 - **Tier 3** MUST send a detailed notification at the end of every execution, regardless of outcome.
 
+<!-- Governing: SPEC-0010 REQ-9 (Subagent Spawning via Task Tool — tiered escalation without custom orchestration code) -->
 ## Model Escalation
 
 When spawning subagents for escalation, use the Task tool:

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -37,6 +37,7 @@ if [ ! -f "${STATE_DIR}/cooldown.json" ]; then
     echo '{"services":{},"last_run":null,"last_daily_digest":null}' > "${STATE_DIR}/cooldown.json"
 fi
 
+# Governing: SPEC-0010 REQ-8 (MCP Server Configuration — merge repo configs into baseline before each CLI invocation)
 # Merge MCP configs from mounted repos into the baseline config.
 # Each repo can provide .claude-ops/mcp.json with additional MCP servers.
 # These are merged (repo configs added to baseline) before each run.
@@ -106,7 +107,7 @@ while true; do
         --allowedTools "${ALLOWED_TOOLS}" \
         --disallowedTools "${DISALLOWED_TOOLS}" \
         --append-system-prompt "Environment: ${ENV_CONTEXT}" \
-        2>&1 | tee -a "${LOG_FILE}" || true
+        2>&1 | tee -a "${LOG_FILE}" || true  # Governing: SPEC-0010 REQ-10 (Error Handling — || true prevents set -e from terminating loop)
 
     RUN_END=$(date -u +%Y-%m-%dT%H:%M:%SZ)
     echo "[${RUN_END}] Run complete. Sleeping ${INTERVAL}s..."


### PR DESCRIPTION
## Summary
- Verifies and adds governing comments for four SPEC-0010 requirements:
  - **REQ-8** (MCP Server Configuration): `entrypoint.sh` `merge_mcp_configs()` merges repo `.claude-ops/mcp.json` into baseline before each CLI invocation
  - **REQ-9** (Subagent Spawning via Task Tool): `CLAUDE.md` Model Escalation section documents Task tool usage for tiered escalation without custom orchestration code
  - **REQ-10** (Error Handling and Exit Codes): `entrypoint.sh` uses `|| true` on the `claude` invocation to prevent `set -e` from terminating the loop on non-zero exits
  - **REQ-11** (Zero Application Code Constraint): `CLAUDE.md` Architecture section affirms no application code, no `src/` directory, CLI-provided features only

Closes #329
Part of epic #141
Part of SPEC-0010

## Test plan
- [x] `go vet ./...` passes
- [x] `go test ./... -count=1 -race` passes
- [ ] Verify governing comments are present in the correct locations

🤖 Generated with [Claude Code](https://claude.com/claude-code)