### PR TITLE
Tool Filtering & Permissions (SPEC-0010 REQ-5)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -116,6 +116,11 @@ Extensions from all mounted repos are combined. Custom checks, playbooks, and sk
 
 ## Permission Tiers
 
+<!-- Governing: SPEC-0010 REQ-5 "Tool filtering via --allowedTools" -->
+<!-- Tool restrictions are enforced at the CLI runtime level via --allowedTools
+     and --disallowedTools flags, providing defense-in-depth beyond prompt-level
+     instructions. Each tier gets progressively more tools. -->
+
 ### Tier 1 — Haiku (Observe Only)
 
 You may:

--- a/cmd/claudeops/main.go
+++ b/cmd/claudeops/main.go
@@ -40,6 +40,7 @@ func main() {
 	f.String("state-dir", "/state", "directory for persistent state")
 	f.String("results-dir", "/results", "directory for session logs")
 	f.String("repos-dir", "/repos", "directory for cloned repositories")
+	// Governing: SPEC-0010 REQ-5 "Tool filtering via --allowedTools"
 	f.String("allowed-tools", "Bash,Read,Write,Edit,Grep,Glob,Task,WebFetch", "comma-separated Claude tools")
 	f.Bool("dry-run", false, "skip actual remediation actions")
 	f.Bool("verbose", false, "enable verbose Claude CLI output")

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -7,8 +7,11 @@ MODEL="${CLAUDEOPS_TIER1_MODEL:-haiku}"
 STATE_DIR="${CLAUDEOPS_STATE_DIR:-/state}"
 RESULTS_DIR="${CLAUDEOPS_RESULTS_DIR:-/results}"
 REPOS_DIR="${CLAUDEOPS_REPOS_DIR:-/repos}"
+# Governing: SPEC-0010 REQ-5 "Tool filtering via --allowedTools"
+# — restricts available tools at the CLI runtime level, providing defense-in-depth
+# for the permission tier model. Tier 1 default: read-only tools.
 ALLOWED_TOOLS="${CLAUDEOPS_ALLOWED_TOOLS:-Bash,Read,Grep,Glob,Task,WebFetch}"
-# Governing: ADR-0023 (AllowedTools-Based Tier Enforcement)
+# Governing: ADR-0023 (AllowedTools-Based Tier Enforcement), SPEC-0010 REQ-5
 # Default to Tier 1 blocklist (most restrictive)
 DISALLOWED_TOOLS="${CLAUDEOPS_DISALLOWED_TOOLS:-Bash(docker restart:*),Bash(docker stop:*),Bash(docker start:*),Bash(docker rm:*),Bash(docker compose:*),Bash(ansible:*),Bash(ansible-playbook:*),Bash(helm:*),Bash(gh pr create:*),Bash(gh pr merge:*),Bash(tea pr create:*),Bash(git push:*),Bash(git commit:*),Bash(systemctl restart:*),Bash(systemctl stop:*),Bash(systemctl start:*),Bash(apprise:*)}"
 CLAUDEOPS_TIER="${CLAUDEOPS_TIER:-1}"
@@ -87,6 +90,8 @@ while true; do
     fi
 
     # Run Claude with tier 1 prompt
+    # Governing: SPEC-0010 REQ-5 — --allowedTools and --disallowedTools enforce
+    # tool filtering at CLI runtime, independent of prompt-level instructions.
     claude \
         --model "${MODEL}" \
         -p "$(cat "${PROMPT_FILE}")" \

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -15,7 +15,7 @@ type Config struct {
 	StateDir      string
 	ResultsDir    string
 	ReposDir      string
-	AllowedTools  string
+	AllowedTools  string // Governing: SPEC-0010 REQ-5 "Tool filtering via --allowedTools"
 	DryRun        bool
 	AppriseURLs   string
 	MCPConfig     string

--- a/internal/session/runner.go
+++ b/internal/session/runner.go
@@ -21,6 +21,8 @@ type CLIRunner struct{}
 // It returns a reader for stdout, a wait function that blocks until the
 // process exits, and any startup error.
 func (r *CLIRunner) Start(ctx context.Context, model string, promptContent string, allowedTools string, appendSystemPrompt string) (io.ReadCloser, func() error, error) {
+	// Governing: SPEC-0010 REQ-5 "Tool filtering via --allowedTools"
+	// — enforces tool restrictions at CLI runtime, not just prompt level.
 	args := []string{
 		"--model", model,
 		"-p", promptContent,


### PR DESCRIPTION
## Summary

- Adds governing comments tracing implementation back to SPEC-0010 REQ-5 (Tool filtering via --allowedTools)
- Annotates the `--allowedTools` / `--disallowedTools` enforcement across the entrypoint script, Go session runner, config, and CLI flag definition
- Documents defense-in-depth tool filtering in the CLAUDE.md Permission Tiers section

## Files Changed

- `entrypoint.sh` — REQ-5 governing comments on `ALLOWED_TOOLS`, `DISALLOWED_TOOLS` variables and the CLI invocation flags
- `internal/session/runner.go` — REQ-5 governing comment on `--allowedTools` in CLI args
- `internal/config/config.go` — REQ-5 governing comment on `AllowedTools` config field
- `cmd/claudeops/main.go` — REQ-5 governing comment on `allowed-tools` flag definition
- `CLAUDE.md` — REQ-5 governing comment in Permission Tiers section documenting runtime enforcement

## Test plan

- [x] `go vet ./...` passes
- [x] `go test ./... -count=1 -race` passes

Closes #327
Part of epic #141
Part of SPEC-0010

🤖 Generated with [Claude Code](https://claude.com/claude-code)