### PR TITLE
Add governing comments for model & prompt configuration (SPEC-0010 REQ-3/4)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -54,6 +54,8 @@ This is not a traditional codebase — there is no application code to compile o
 
 ### Execution flow
 
+<!-- Governing: SPEC-0010 REQ-3 (model selection), REQ-4 (prompt loading) -->
+
 `entrypoint.sh` runs an infinite loop:
 1. Merges MCP configs from mounted repos into `.claude/mcp.json`
 2. Invokes `claude --model haiku --prompt-file prompts/tier1-observe.md`
@@ -225,6 +227,8 @@ When spawning subagents for escalation, use the Task tool:
 Always pass the full context of what was found to the next tier. The escalated agent should not need to re-run checks — it should pick up from where you left off.
 
 ## Escalation Model Config
+
+<!-- Governing: SPEC-0010 REQ-3 — Model Selection via --model Flag and CLAUDEOPS_TIER*_MODEL env vars -->
 
 - Tier 1 model: `$CLAUDEOPS_TIER1_MODEL` (default: `haiku`)
 - Tier 2 model: `$CLAUDEOPS_TIER2_MODEL` (default: `sonnet`)

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -2,8 +2,10 @@
 set -euo pipefail
 
 INTERVAL="${CLAUDEOPS_INTERVAL:-3600}"
+# Governing: SPEC-0010 REQ-4 — Prompt Loading via --prompt-file
 PROMPT_FILE="${CLAUDEOPS_PROMPT:-/app/prompts/tier1-observe.md}"
 # Governing: SPEC-0001 REQ-1 (Three-Tier Model Hierarchy), REQ-2 (Configurable Model Selection)
+# Governing: SPEC-0010 REQ-3 — Model Selection via --model Flag
 MODEL="${CLAUDEOPS_TIER1_MODEL:-haiku}"
 STATE_DIR="${CLAUDEOPS_STATE_DIR:-/state}"
 RESULTS_DIR="${CLAUDEOPS_RESULTS_DIR:-/results}"
@@ -85,6 +87,7 @@ while true; do
     ENV_CONTEXT="${ENV_CONTEXT} CLAUDEOPS_RESULTS_DIR=${RESULTS_DIR}"
     ENV_CONTEXT="${ENV_CONTEXT} CLAUDEOPS_REPOS_DIR=${REPOS_DIR}"
     # Governing: SPEC-0001 REQ-1 (Three-Tier Model Hierarchy), REQ-2 (Configurable Model Selection)
+    # Governing: SPEC-0010 REQ-3 — Tier model defaults passed to agent for subagent spawning
     ENV_CONTEXT="${ENV_CONTEXT} CLAUDEOPS_TIER2_MODEL=${CLAUDEOPS_TIER2_MODEL:-sonnet}"
     ENV_CONTEXT="${ENV_CONTEXT} CLAUDEOPS_TIER3_MODEL=${CLAUDEOPS_TIER3_MODEL:-opus}"
 
@@ -98,6 +101,7 @@ while true; do
 
     # Governing: SPEC-0010 REQ-2 (Subprocess Invocation from Bash — CLI flags for all config, non-interactive, piped output)
     # Run Claude with tier 1 prompt
+    # Governing: SPEC-0010 REQ-3 (--model), REQ-4 (--prompt-file)
     # Governing: SPEC-0010 REQ-5 — --allowedTools and --disallowedTools enforce
     # tool filtering at CLI runtime, independent of prompt-level instructions.
     claude \


### PR DESCRIPTION
## Summary

- Added governing comments to `entrypoint.sh` tracing model selection (`--model` flag, `CLAUDEOPS_TIER*_MODEL` env vars) and prompt loading (`--prompt-file`, `CLAUDEOPS_PROMPT` env var) back to SPEC-0010 REQ-3 and REQ-4
- Added governing comments to `CLAUDE.md` in the "Execution flow" and "Escalation Model Config" sections

Closes #326 / Part of epic #141 / Part of SPEC-0010

## Test plan

- [x] `go vet ./...` passes
- [x] `go test ./... -count=1 -race` passes
- [ ] Verify governing comments are present in `entrypoint.sh` (lines 5-7, 82, 91)
- [ ] Verify governing comments are present in `CLAUDE.md` (Execution flow, Escalation Model Config)

🤖 Generated with [Claude Code](https://claude.com/claude-code)