### PR TITLE
Add SPEC-0011 governing comments for CLI output format and NDJSON preservation

### DIFF
--- a/internal/session/manager.go
+++ b/internal/session/manager.go
@@ -317,6 +317,7 @@ func (m *Manager) runTier(ctx context.Context, tier int, model string, promptFil
 			raw := m.redactor.Redact(scanner.Text())
 			ts := time.Now().UTC()
 
+			// Governing: SPEC-0011 "Raw NDJSON Log Preservation" (every raw line written unmodified for auditability)
 			// Write timestamped JSON to log file for forensic analysis.
 			_, _ = fmt.Fprintf(logFile, "%s\t%s\n", ts.Format(time.RFC3339Nano), raw)
 

--- a/internal/session/runner.go
+++ b/internal/session/runner.go
@@ -17,6 +17,7 @@ type ProcessRunner interface {
 // CLIRunner implements ProcessRunner by spawning the real `claude` CLI binary.
 type CLIRunner struct{}
 
+// Governing: SPEC-0011 "CLI Invocation with stream-json" (--output-format stream-json for structured NDJSON events)
 // Start builds and starts a claude CLI process with stream-json output.
 // It returns a reader for stdout, a wait function that blocks until the
 // process exits, and any startup error.


### PR DESCRIPTION
## Summary
- Verifies and adds governing comments for two SPEC-0011 requirements:
  - **CLI Invocation with stream-json**: `internal/session/runner.go` `CLIRunner.Start()` passes `--output-format stream-json` to the Claude CLI for structured NDJSON event output
  - **Raw NDJSON Log Preservation**: `internal/session/manager.go` writes every raw NDJSON line to the session log file with timestamps for forensic auditability

Closes #330
Part of epic #6
Part of SPEC-0011

## Test plan
- [x] `go vet ./...` passes
- [x] `go test ./... -count=1 -race` passes
- [ ] Verify governing comments are present in the correct locations

🤖 Generated with [Claude Code](https://claude.com/claude-code)