### PR TITLE
Add SPEC-0011 governing comments for SSE streaming and session page

### DIFF
--- a/internal/session/manager.go
+++ b/internal/session/manager.go
@@ -516,7 +516,7 @@ type contentBlock struct {
 // FormatStreamEvent parses a raw NDJSON line and returns a human-readable
 // formatted string for display in the terminal and SSE hub. Returns "" for
 // events that should be suppressed (e.g. unknown types, non-init system events).
-// Governing: SPEC-0011 "Event Parsing and Formatting" — formats system, assistant, user, result events
+// Governing: SPEC-0011 "Event Parsing and Formatting" — formats system, assistant, user, result events; format NDJSON events for display.
 func FormatStreamEvent(raw string) string {
 	var evt streamEvent
 	if err := json.Unmarshal([]byte(raw), &evt); err != nil {
@@ -657,7 +657,7 @@ func stripANSI(s string) string {
 // FormatStreamEventHTML returns an HTML-formatted version of a stream event
 // with rich markup mimicking the Claude CLI terminal experience. Suitable for
 // SSE delivery and browser display. Returns "" for suppressed events.
-// Governing: SPEC-0011 "Event Parsing and Formatting" — HTML variant for browser display
+// Governing: SPEC-0011 "Event Parsing and Formatting" — HTML variant for browser display; HTML-formatted events for SSE and log replay.
 func FormatStreamEventHTML(raw string) string {
 	var evt streamEvent
 	if err := json.Unmarshal([]byte(raw), &evt); err != nil {

--- a/internal/web/handlers.go
+++ b/internal/web/handlers.go
@@ -153,6 +153,7 @@ func (s *Server) handleSessions(w http.ResponseWriter, r *http.Request) {
 
 // handleSession renders a single session detail view.
 // Governing: SPEC-0008 REQ-10 — session view page: streaming output, tier level, and target service.
+// Governing: SPEC-0011 "Session Page Layout" — back link, header, metadata, response, activity log, log path.
 func (s *Server) handleSession(w http.ResponseWriter, r *http.Request) {
 	idStr := r.PathValue("id")
 	id, err := strconv.ParseInt(idStr, 10, 64)
@@ -226,6 +227,7 @@ func (s *Server) handleSession(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
+	// Governing: SPEC-0011 "Log File Formatting on Read Path" — format NDJSON log line-by-line.
 	// Read and format log file contents if available.
 	// Log files contain timestamped NDJSON from --output-format stream-json.
 	// Format: "2006-01-02T15:04:05Z\t{json}" per line (or legacy raw JSON).
@@ -271,6 +273,7 @@ func (s *Server) handleSession(w http.ResponseWriter, r *http.Request) {
 // handleSessionStream opens an SSE connection for a running session.
 // Governing: SPEC-0008 REQ-3 — HTMX-Based Interactivity (hx-ext="sse" for real-time streaming)
 // Governing: SPEC-0008 REQ-10 — session view real-time streaming via SSE.
+// Governing: SPEC-0011 "SSE Streaming of Formatted Events" — deliver formatted lines to browsers via SSE.
 func (s *Server) handleSessionStream(w http.ResponseWriter, r *http.Request) {
 	idStr := r.PathValue("id")
 	id, err := strconv.Atoi(idStr)

--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -189,6 +189,7 @@ func (s *Server) parseTemplates() {
 			}
 			return *p
 		},
+		// Governing: SPEC-0011 "Markdown Response Rendering" — server-side goldmark rendering.
 		"renderMarkdown": func(md string) template.HTML {
 			gm := goldmark.New(
 				goldmark.WithExtensions(

--- a/internal/web/templates/session.html
+++ b/internal/web/templates/session.html
@@ -84,7 +84,8 @@
     </div>
     {{end}}
 
-    {{/* Response — rendered markdown at the top */}}
+    {{/* Governing: SPEC-0011 "Session Page Layout" — response card above activity log */}}
+    {{/* Governing: SPEC-0011 "Markdown Response Rendering" — renderMarkdown via goldmark */}}
     {{if .Session.Response}}
     <section class="mb-6">
         <h2 class="section-heading">Response</h2>
@@ -94,7 +95,8 @@
     </section>
     {{end}}
 
-    {{/* Activity log — CLI output */}}
+    {{/* Governing: SPEC-0011 "Session Page Layout" — activity log section */}}
+    {{/* Governing: SPEC-0011 "SSE Streaming of Formatted Events" — hx-ext=sse for running sessions */}}
     <section>
         <h2 class="section-heading">Activity Log</h2>
         {{if eq .Session.Status "running"}}


### PR DESCRIPTION
## Summary

- Adds governing comments tracing SPEC-0011 requirements to their implementations:
  - **SSE Streaming of Formatted Events**: `handleSessionStream` in `handlers.go`, `hx-ext=sse` in `session.html`
  - **Session Page Layout**: `handleSession` in `handlers.go`, template structure in `session.html` (back link, header, metadata, response, activity log, log path)
  - **Markdown Response Rendering**: `renderMarkdown` template function in `server.go` (goldmark), `{{renderMarkdown}}` call in `session.html`
  - **Event Parsing and Formatting**: `FormatStreamEvent` and `FormatStreamEventHTML` in `manager.go`
  - **Log File Formatting on Read Path**: NDJSON log read section in `handleSession`

## Test plan

- [x] `go vet ./...` passes
- [x] `go test ./... -count=1 -race` passes
- [ ] Verify governing comments are correctly placed next to the relevant implementation code

Closes #333
Part of epic #6
Part of SPEC-0011