### PR TITLE
Result Metadata & DB Schema (SPEC-0011)

### DIFF
--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -191,6 +191,8 @@ func (d *DB) UpdateSessionStatus(id int64, status string) error {
 
 // UpdateSessionResult stores the final response and metadata from a completed session.
 // Governing: SPEC-0016 REQ "Per-Tier Cost Attribution" — each tier records cost_usd, num_turns, duration_ms independently
+// Governing: SPEC-0011 REQ "Result Event Metadata Extraction", REQ "Database Schema for Session Metadata"
+// — persists result, total_cost_usd, num_turns, and duration_ms extracted from the result event.
 func (d *DB) UpdateSessionResult(id int64, response string, costUSD float64, numTurns int, durationMs int64) error {
 	_, err := d.conn.Exec(
 		`UPDATE sessions SET response = ?, cost_usd = ?, num_turns = ?, duration_ms = ? WHERE id = ?`,

--- a/internal/db/migrations/00002_session_metadata.sql
+++ b/internal/db/migrations/00002_session_metadata.sql
@@ -1,3 +1,5 @@
+-- Governing: SPEC-0011 REQ "Database Schema for Session Metadata"
+-- Adds nullable columns for result event metadata: response, cost, turns, duration.
 -- +goose Up
 ALTER TABLE sessions ADD COLUMN response TEXT;
 ALTER TABLE sessions ADD COLUMN cost_usd REAL;


### PR DESCRIPTION
## Summary

- Adds governing comments tracing implementation back to SPEC-0011 requirements for Result Event Metadata Extraction and Database Schema for Session Metadata
- Annotates the migration file, DB update function, stream event struct, and result extraction/storage logic in the session manager

## Files Changed

- `internal/db/migrations/00002_session_metadata.sql` — Governing comment linking migration to SPEC-0011 REQ "Database Schema for Session Metadata"
- `internal/db/db.go` — Governing comment on `UpdateSessionResult()` linking to both metadata extraction and schema requirements
- `internal/session/manager.go` — Governing comments on result metadata variables, `streamEvent` result fields, and the `UpdateSessionResult` call site

## Test plan

- [x] `go vet ./...` passes
- [x] `go test ./... -count=1 -race` passes

Closes #332
Part of epic #6
Part of SPEC-0011

🤖 Generated with [Claude Code](https://claude.com/claude-code)