### PR TITLE
Add governing comments for event parsing & log formatting (SPEC-0011)

### DIFF
--- a/internal/session/manager.go
+++ b/internal/session/manager.go
@@ -481,6 +481,7 @@ type contentBlock struct {
 // FormatStreamEvent parses a raw NDJSON line and returns a human-readable
 // formatted string for display in the terminal and SSE hub. Returns "" for
 // events that should be suppressed (e.g. unknown types, non-init system events).
+// Governing: SPEC-0011 "Event Parsing and Formatting" — formats system, assistant, user, result events
 func FormatStreamEvent(raw string) string {
 	var evt streamEvent
 	if err := json.Unmarshal([]byte(raw), &evt); err != nil {
@@ -621,6 +622,7 @@ func stripANSI(s string) string {
 // FormatStreamEventHTML returns an HTML-formatted version of a stream event
 // with rich markup mimicking the Claude CLI terminal experience. Suitable for
 // SSE delivery and browser display. Returns "" for suppressed events.
+// Governing: SPEC-0011 "Event Parsing and Formatting" — HTML variant for browser display
 func FormatStreamEventHTML(raw string) string {
 	var evt streamEvent
 	if err := json.Unmarshal([]byte(raw), &evt); err != nil {
@@ -884,6 +886,7 @@ func WrapLogLine(num int, ts string, content string) string {
 }
 
 // ParseTimestampedLogLine splits a log line into timestamp and raw JSON.
+// Governing: SPEC-0011 "Log File Formatting on Read Path" — parse timestamped NDJSON for display
 // Log lines may be in timestamped format "2006-01-02T15:04:05Z\t{json}" or
 // legacy format with just raw JSON.
 func ParseTimestampedLogLine(line string) (ts time.Time, raw string, hasTS bool) {

--- a/internal/web/handlers.go
+++ b/internal/web/handlers.go
@@ -226,6 +226,7 @@ func (s *Server) handleSession(w http.ResponseWriter, r *http.Request) {
 	// Log files contain timestamped NDJSON from --output-format stream-json.
 	// Format: "2006-01-02T15:04:05Z\t{json}" per line (or legacy raw JSON).
 	// We use FormatStreamEventHTML to produce color-coded HTML output.
+	// Governing: SPEC-0011 "Log File Formatting on Read Path" — line-by-line formatting via scanner
 	var output string
 	if sess.LogFile != nil && *sess.LogFile != "" {
 		if f, err := os.Open(*sess.LogFile); err == nil {


### PR DESCRIPTION
## Summary

- Added governing comments to `FormatStreamEvent` and `FormatStreamEventHTML` in `internal/session/manager.go` tracing to SPEC-0011 "Event Parsing and Formatting"
- Added governing comment to `ParseTimestampedLogLine` in `internal/session/manager.go` tracing to SPEC-0011 "Log File Formatting on Read Path"
- Added governing comment to the log file read-path in `internal/web/handlers.go` tracing to SPEC-0011 "Log File Formatting on Read Path"

Closes #331
Part of epic #6
Part of SPEC-0011

## Test plan

- [x] `go vet ./...` passes
- [x] `go test ./... -count=1 -race` passes
- [ ] Verify governing comments in `internal/session/manager.go` (FormatStreamEvent, FormatStreamEventHTML, ParseTimestampedLogLine)
- [ ] Verify governing comment in `internal/web/handlers.go` (log file read-path)

🤖 Generated with [Claude Code](https://claude.com/claude-code)