### PR TITLE
Add SPEC-0012 governing comments for ad-hoc session execution and busy rejection

### DIFF
--- a/internal/session/manager.go
+++ b/internal/session/manager.go
@@ -50,6 +50,7 @@ func New(cfg *config.Config, database *db.DB, h *hub.Hub, runner ProcessRunner) 
 	}
 }
 
+// Governing: SPEC-0012 REQ "Busy Rejection When Session Already Running" (mutex check + channel buffer rejects concurrent triggers)
 // TriggerAdHoc sends a prompt to trigger an immediate session.
 // Returns the session ID once created, or error if busy.
 func (m *Manager) TriggerAdHoc(prompt string) (int64, error) {
@@ -98,6 +99,7 @@ func (m *Manager) Run(ctx context.Context) error {
 	}
 }
 
+// Governing: SPEC-0012 REQ "Ad-Hoc Session Uses runOnce with Custom Prompt" (custom prompt via promptOverride, identical lifecycle to scheduled)
 // runAdHoc handles a manually triggered session with full escalation support.
 func (m *Manager) runAdHoc(ctx context.Context, prompt string) {
 	m.runEscalationChain(ctx, "manual", &prompt)


### PR DESCRIPTION
## Summary
- Verifies and adds governing comments for two SPEC-0012 requirements:
  - **Ad-Hoc Session Uses runOnce with Custom Prompt**: `internal/session/manager.go` `runAdHoc()` passes custom prompt as `promptOverride` to `runEscalationChain()`, reusing the same session lifecycle (DB record, log file, SSE streaming, result capture) as scheduled sessions
  - **Busy Rejection When Session Already Running**: `TriggerAdHoc()` checks `m.running` under mutex and uses a buffered channel (size 1) to reject concurrent triggers; web handlers return HTTP 409 Conflict

Closes #335
Part of epic #60
Part of SPEC-0012

## Test plan
- [x] `go vet ./...` passes
- [x] `go test ./... -count=1 -race` passes
- [ ] Verify governing comments are present in the correct locations

🤖 Generated with [Claude Code](https://claude.com/claude-code)