### PR TITLE
Add governing comments for HTTP endpoint & HTMX form (SPEC-0012)

### DIFF
--- a/internal/session/manager.go
+++ b/internal/session/manager.go
@@ -52,6 +52,7 @@ func New(cfg *config.Config, database *db.DB, h *hub.Hub, runner ProcessRunner) 
 
 // TriggerAdHoc sends a prompt to trigger an immediate session.
 // Returns the session ID once created, or error if busy.
+// Governing: SPEC-0012 "TriggerAdHoc Public API" — channel-based trigger, busy rejection
 func (m *Manager) TriggerAdHoc(prompt string) (int64, error) {
 	m.mu.Lock()
 	if m.running {

--- a/internal/web/handlers.go
+++ b/internal/web/handlers.go
@@ -511,6 +511,7 @@ func (s *Server) handleConfigGet(w http.ResponseWriter, r *http.Request) {
 }
 
 // handleTriggerSession triggers an ad-hoc session with a custom prompt.
+// Governing: SPEC-0012 "POST /sessions/trigger Endpoint" — form-encoded prompt, 400/409/200 responses
 func (s *Server) handleTriggerSession(w http.ResponseWriter, r *http.Request) {
 	if err := r.ParseForm(); err != nil {
 		http.Error(w, "bad form data", http.StatusBadRequest)

--- a/internal/web/templates/layout.html
+++ b/internal/web/templates/layout.html
@@ -99,7 +99,7 @@
             {{.Content}}
         </main>
     </div>
-    {{/* Run Now modal */}}
+    {{/* Run Now modal — Governing: SPEC-0012 "HTMX Form on Dashboard" */}}
     <dialog id="run-modal" class="run-modal">
         <div class="run-modal-box">
             <div class="flex items-center justify-between mb-4">


### PR DESCRIPTION
## Summary

- Added governing comment to `handleTriggerSession` in `internal/web/handlers.go` tracing to SPEC-0012 "POST /sessions/trigger Endpoint"
- Added governing comment to the Run Now modal in `internal/web/templates/layout.html` tracing to SPEC-0012 "HTMX Form on Dashboard"
- Added governing comment to `TriggerAdHoc` in `internal/session/manager.go` tracing to SPEC-0012 "TriggerAdHoc Public API"

Closes #336
Part of epic #60
Part of SPEC-0012

## Test plan

- [x] `go vet ./...` passes
- [x] `go test ./... -count=1 -race` passes
- [ ] Verify governing comment in `internal/web/handlers.go` (handleTriggerSession)
- [ ] Verify governing comment in `internal/web/templates/layout.html` (Run Now modal)
- [ ] Verify governing comment in `internal/session/manager.go` (TriggerAdHoc)

🤖 Generated with [Claude Code](https://claude.com/claude-code)