### PR TITLE
Add SPEC-0012 governing comments for trigger metadata, session list, and detail display

### DIFF
--- a/internal/db/migrations/00003_session_trigger.sql
+++ b/internal/db/migrations/00003_session_trigger.sql
@@ -1,3 +1,4 @@
+-- Governing: SPEC-0012 REQ "Session Database Record with Trigger Metadata" (trigger + prompt_text columns)
 -- +goose Up
 ALTER TABLE sessions ADD COLUMN trigger TEXT NOT NULL DEFAULT 'scheduled';
 ALTER TABLE sessions ADD COLUMN prompt_text TEXT;

--- a/internal/web/templates/session.html
+++ b/internal/web/templates/session.html
@@ -28,6 +28,7 @@
                 <div class="meta-label">Duration</div>
                 <div class="font-mono text-xs">{{fmtDuration .Session.StartedAt .Session.EndedAt}}</div>
             </div>
+            <!-- Governing: SPEC-0012 REQ "Session Detail Shows Trigger Metadata" -->
             <div>
                 <div class="meta-label">Trigger</div>
                 <div>{{.Session.Trigger}}</div>

--- a/internal/web/templates/sessions.html
+++ b/internal/web/templates/sessions.html
@@ -12,6 +12,7 @@
                         <th class="pb-3 pr-4">Tier</th>
                         <th class="pb-3 pr-4">Model</th>
                         <th class="pb-3 pr-4">Status</th>
+                        <!-- Governing: SPEC-0012 REQ "Session List Shows Trigger Type" -->
                         <th class="pb-3 pr-4">Trigger</th>
                         <th class="pb-3 pr-4">Duration</th>
                         <th class="pb-3 pr-4">Cost</th>


### PR DESCRIPTION
## Summary
- Verifies and adds governing comments for four SPEC-0012 requirements:
  - **Session Database Record with Trigger Metadata**: Migration `00003_session_trigger.sql` adds `trigger TEXT NOT NULL DEFAULT 'scheduled'` and `prompt_text TEXT` columns
  - **Session List Shows Trigger Type**: `sessions.html` displays a Trigger column with styled badge (accent for "manual", muted for "scheduled")
  - **Session Detail Shows Trigger Metadata**: `session.html` shows trigger type in metadata card and conditionally displays ad-hoc prompt text
  - **SSE Streaming Works Identically**: Verified `runTier()` handles both scheduled and ad-hoc sessions with the same SSE hub publish logic (no code changes needed, no governing comment added since there is no distinct code path)

Closes #337
Part of epic #60
Part of SPEC-0012

## Test plan
- [x] `go vet ./...` passes
- [x] `go test ./... -count=1 -race` passes
- [ ] Verify governing comments are present in the correct locations

🤖 Generated with [Claude Code](https://claude.com/claude-code)