### PR TITLE
Add governing comments for real-time UI polling & cost display (SPEC-0013)

### DIFF
--- a/internal/web/handlers.go
+++ b/internal/web/handlers.go
@@ -17,6 +17,7 @@ import (
 
 // handleIndex renders the overview dashboard.
 // Governing: SPEC-0021 REQ "TL;DR Page Rendering"
+// Governing: SPEC-0013 "Real-Time Overview" — serves polling endpoint for HTMX auto-refresh
 func (s *Server) handleIndex(w http.ResponseWriter, r *http.Request) {
 	var sessionView *SessionView
 	if latest, err := s.db.LatestSession(); err != nil {
@@ -58,6 +59,7 @@ func (s *Server) handleIndex(w http.ResponseWriter, r *http.Request) {
 }
 
 // handleSessions renders the session list.
+// Governing: SPEC-0013 "Real-Time Sessions List" — serves polling endpoint for HTMX auto-refresh
 func (s *Server) handleSessions(w http.ResponseWriter, r *http.Request) {
 	sessions, err := s.db.ListSessions(50, 0)
 	if err != nil {

--- a/internal/web/templates/index.html
+++ b/internal/web/templates/index.html
@@ -3,7 +3,7 @@
 <div class="max-w-6xl" id="overview-content">
     <h1 class="text-2xl font-semibold mb-6">TL;DR</h1>
 
-    {{/* Recent events feed */}}
+    {{/* Recent events feed — Governing: SPEC-0013 "Real-Time Overview" — hx-trigger every 10s polling */}}
     <section class="mb-8" id="events-feed" hx-get="/" hx-trigger="every 10s" hx-select="#events-feed-inner" hx-target="#events-feed-inner" hx-swap="outerHTML">
         <h2 class="section-heading">Recent Events</h2>
         <div id="events-feed-inner">
@@ -25,7 +25,7 @@
         </div>
     </section>
 
-    {{/* Last session summary */}}
+    {{/* Last session summary — Governing: SPEC-0013 "Real-Time Overview" — auto-refresh last session card */}}
     <section class="mb-8" id="last-session" hx-get="/" hx-trigger="every 10s" hx-select="#last-session-inner" hx-target="#last-session-inner" hx-swap="outerHTML">
         <h2 class="section-heading">Latest Session Summary</h2>
         <div id="last-session-inner">

--- a/internal/web/templates/sessions.html
+++ b/internal/web/templates/sessions.html
@@ -1,3 +1,5 @@
+{{/* Governing: SPEC-0013 "Real-Time Sessions List" — hx-trigger every 5s polling, cost/turns columns */}}
+{{/* Governing: SPEC-0013 "Sessions Display Cost and Tokens" — Cost and Turns columns in table */}}
 {{define "sessions.html"}}
 <div class="max-w-5xl">
     <h1 class="text-2xl font-semibold mb-6">Sessions</h1>


### PR DESCRIPTION
## Summary

- Added governing comments to `sessions.html` tracing HTMX polling (`hx-trigger="every 5s"`) to SPEC-0013 "Real-Time Sessions List" and Cost/Turns columns to SPEC-0013 "Sessions Display Cost and Tokens"
- Added governing comments to `index.html` tracing HTMX polling on the events feed and last session card (`hx-trigger="every 10s"`) to SPEC-0013 "Real-Time Overview"
- Added governing comments to `handleSessions` and `handleIndex` in `handlers.go` as the server-side polling endpoints for SPEC-0013

Closes #338
Part of epic #105
Part of SPEC-0013

## Test plan

- [x] `go vet ./...` passes
- [x] `go test ./... -count=1 -race` passes
- [ ] Verify governing comments in `internal/web/templates/sessions.html` (Real-Time Sessions List, Sessions Display Cost and Tokens)
- [ ] Verify governing comments in `internal/web/templates/index.html` (Real-Time Overview on events feed and last session)
- [ ] Verify governing comments in `internal/web/handlers.go` (handleSessions, handleIndex)

🤖 Generated with [Claude Code](https://claude.com/claude-code)