### PR TITLE
Services UI Removal governing comments (SPEC-0013)

### DIFF
--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -312,6 +312,7 @@ func (s *Server) parseTemplates() {
 
 // Governing: SPEC-0008 REQ-14 — Static Asset Embedding (static files served from embed.FS)
 // Governing: SPEC-0008 REQ-10 — dashboard pages: overview, session view, cooldowns, config, events, memories.
+// Governing: SPEC-0013 "Remove Services UI" — no /services routes registered
 func (s *Server) registerRoutes() {
 	staticSub, _ := fs.Sub(staticFS, "static")
 	s.mux.Handle("GET /static/", http.StripPrefix("/static/", http.FileServer(http.FS(staticSub))))

--- a/internal/web/templates/layout.html
+++ b/internal/web/templates/layout.html
@@ -22,6 +22,7 @@
                     <span class="brand-text">CLAUDE OPS</span>
                 </a>
             </div>
+            {{/* Governing: SPEC-0013 "Remove Services UI" — no Services entry in navigation */}}
             <ul class="flex-1 py-3">
                 <li>
                     <a href="/"


### PR DESCRIPTION
## Summary
- Adds SPEC-0013 governing comments confirming Services UI has been removed per the "Remove Services UI" requirement
- `internal/web/server.go`: Comment on `registerRoutes()` noting no `/services` routes are registered
- `internal/web/templates/layout.html`: Comment on navigation noting no "Services" entry exists
- `health_checks` table is retained for internal agent use per design doc (not exposed in UI)

## Verification
- Confirmed no `/services` or `/services/{name}` routes exist in `registerRoutes()`
- Confirmed no "Services" link in sidebar navigation (`layout.html`)
- Confirmed no `handleService*` handlers exist in the web package
- Confirmed no `service*.html` templates exist
- All tests pass (`go test ./... -count=1 -race`)

Closes #339
Part of epic #105
Part of SPEC-0013

## Test plan
- [x] `go vet ./...` passes
- [x] `go test ./... -count=1 -race` passes
- [x] Governing comments reference correct SPEC-0013 requirement
- [x] No services routes, handlers, templates, or nav links exist

🤖 Generated with [Claude Code](https://claude.com/claude-code)