### PR TITLE
Add SPEC-0013 governing comments for events table and marker parsing

### DIFF
--- a/internal/db/migrations/00004_events.sql
+++ b/internal/db/migrations/00004_events.sql
@@ -1,3 +1,4 @@
+-- Governing: SPEC-0013 REQ "Events Table" (id, session_id, level, service, message, created_at)
 -- +goose Up
 CREATE TABLE events (
     id INTEGER PRIMARY KEY AUTOINCREMENT,

--- a/internal/session/manager.go
+++ b/internal/session/manager.go
@@ -793,6 +793,7 @@ func parseMarkers(re *regexp.Regexp, text string) []markerMatch {
 
 // --- Event markers ---
 
+// Governing: SPEC-0013 REQ "Event Marker Parsing" ([EVENT:level] and [EVENT:level:service] from assistant text only)
 // eventMarkerRe matches [EVENT:level] or [EVENT:level:service] markers in assistant text.
 var eventMarkerRe = regexp.MustCompile(`\[EVENT:(info|warning|critical)(?::([a-zA-Z0-9_-]+))?\]\s*(.+)`)
 


### PR DESCRIPTION
## Summary
- Verifies and adds governing comments for two SPEC-0013 requirements:
  - **Events Table**: Migration `00004_events.sql` creates the `events` SQLite table with `id`, `session_id`, `level`, `service` (nullable), `message`, `created_at` columns and indexes
  - **Event Marker Parsing**: `internal/session/manager.go` defines `eventMarkerRe` regex matching `[EVENT:level]` and `[EVENT:level:service]` patterns, parsed only from assistant text blocks (`evt.Type == "assistant"`), inserted via `db.InsertEvent()`

Closes #340
Part of epic #105
Part of SPEC-0013

## Test plan
- [x] `go vet ./...` passes
- [x] `go test ./... -count=1 -race` passes
- [ ] Verify governing comments are present in the correct locations

🤖 Generated with [Claude Code](https://claude.com/claude-code)