### PR TITLE
Handoff File Format & Lifecycle governing comments (SPEC-0016)

### DIFF
--- a/internal/session/handoff.go
+++ b/internal/session/handoff.go
@@ -7,6 +7,7 @@ import (
 	"path/filepath"
 )
 
+// Governing: SPEC-0016 "Handoff File Format" — versioned JSON schema at $CLAUDEOPS_STATE_DIR/handoff.json
 // Handoff carries context from one escalation tier to the next. The Tier 1
 // agent writes this file when it detects issues requiring higher-tier
 // intervention; the session manager reads it to decide whether (and how)
@@ -21,6 +22,7 @@ type Handoff struct {
 	CooldownState         json.RawMessage  `json:"cooldown_state,omitempty"`
 }
 
+// Governing: SPEC-0016 "Handoff File Format" — check result object structure
 // CheckResult records the outcome of a single health check performed by
 // a tier agent.
 type CheckResult struct {
@@ -34,6 +36,7 @@ type CheckResult struct {
 // handoffFileName is the well-known file name for the handoff payload.
 const handoffFileName = "handoff.json"
 
+// Governing: SPEC-0016 "Handoff File Lifecycle" — supervisor reads handoff after tier exit
 // ReadHandoff reads and parses the handoff file from stateDir.
 // Returns nil, nil if the file does not exist.
 func ReadHandoff(stateDir string) (*Handoff, error) {
@@ -53,6 +56,7 @@ func ReadHandoff(stateDir string) (*Handoff, error) {
 	return &h, nil
 }
 
+// Governing: SPEC-0016 "Handoff File Lifecycle" — supervisor deletes after read or on stale cleanup
 // DeleteHandoff removes the handoff file from stateDir.
 // Returns nil if the file does not exist.
 func DeleteHandoff(stateDir string) error {
@@ -63,6 +67,7 @@ func DeleteHandoff(stateDir string) error {
 	return nil
 }
 
+// Governing: SPEC-0016 "Handoff File Format" — rejects unrecognized schema_version, invalid tiers
 // ValidateHandoff checks that the handoff payload is well-formed and that the
 // recommended tier does not exceed maxTier.
 func ValidateHandoff(h *Handoff, maxTier int) error {

--- a/internal/session/manager.go
+++ b/internal/session/manager.go
@@ -113,6 +113,7 @@ func (m *Manager) runEscalationChain(ctx context.Context, trigger string, prompt
 		fmt.Fprintf(os.Stderr, "decay stale memories: %v\n", err)
 	}
 
+	// Governing: SPEC-0016 "Handoff File Lifecycle" — delete stale handoff before new cycle
 	// Clean up any stale handoff file from a previous run.
 	if err := DeleteHandoff(m.cfg.StateDir); err != nil {
 		fmt.Fprintf(os.Stderr, "cleanup stale handoff: %v\n", err)


### PR DESCRIPTION
## Summary
- Adds SPEC-0016 governing comments to `internal/session/handoff.go` and `internal/session/manager.go`
- "Handoff File Format": `Handoff` struct (versioned JSON schema at `$CLAUDEOPS_STATE_DIR/handoff.json`), `CheckResult` struct (service, check_type, status, error, response_time_ms), `ValidateHandoff` (rejects unrecognized schema versions, invalid tiers, empty services)
- "Handoff File Lifecycle": `ReadHandoff` (supervisor reads after tier exit), `DeleteHandoff` (cleanup after read, stale cleanup, invalid/dry-run deletion), stale handoff cleanup at start of `runEscalationChain`

## Verification
- Confirmed `Handoff` struct fields match spec: schema_version, recommended_tier, services_affected, check_results, investigation_findings, remediation_attempted, cooldown_state
- Confirmed `CheckResult` struct fields match spec: service, check_type, status, error, response_time_ms
- Confirmed lifecycle: stale cleanup before cycle, read after tier exit, delete after consumption/invalid/dry-run
- Confirmed `ValidateHandoff` rejects schema_version != 1, tier < 2 or > 3, tier > maxTier, empty services
- All tests pass including `handoff_test.go` (read, delete, validate scenarios)

Closes #351
Part of epic #90
Part of SPEC-0016

## Test plan
- [x] `go vet ./...` passes
- [x] `go test ./... -count=1 -race` passes
- [x] Governing comments reference correct SPEC-0016 requirement names
- [x] handoff_test.go covers: read nonexistent, read valid, read invalid JSON, delete, validate (8 subcases)

🤖 Generated with [Claude Code](https://claude.com/claude-code)