### PR TITLE
Add governing comments for events pages & prompt integration (SPEC-0013)

### DIFF
--- a/internal/web/handlers.go
+++ b/internal/web/handlers.go
@@ -314,6 +314,7 @@ func (s *Server) handleSessionStream(w http.ResponseWriter, r *http.Request) {
 }
 
 // handleEvents renders the events feed.
+// Governing: SPEC-0013 "Events Page" — reverse-chronological events with HTMX polling
 func (s *Server) handleEvents(w http.ResponseWriter, r *http.Request) {
 	events, err := s.db.ListEvents(100, 0, nil, nil)
 	if err != nil {

--- a/internal/web/templates/events.html
+++ b/internal/web/templates/events.html
@@ -1,3 +1,4 @@
+{{/* Governing: SPEC-0013 "Events Page" — reverse-chronological event list with severity badges and auto-refresh */}}
 {{define "events.html"}}
 <div class="max-w-5xl">
     <h1 class="text-2xl font-semibold mb-6">Events</h1>

--- a/internal/web/templates/index.html
+++ b/internal/web/templates/index.html
@@ -3,7 +3,7 @@
 <div class="max-w-6xl" id="overview-content">
     <h1 class="text-2xl font-semibold mb-6">TL;DR</h1>
 
-    {{/* Recent events feed — Governing: SPEC-0013 "Real-Time Overview" — hx-trigger every 10s polling */}}
+    {{/* Recent events feed — Governing: SPEC-0013 "Real-Time Overview" — hx-trigger every 10s polling; "Events on Overview Page" — top 10 events with "View all" link */}}
     <section class="mb-8" id="events-feed" hx-get="/" hx-trigger="every 10s" hx-select="#events-feed-inner" hx-target="#events-feed-inner" hx-swap="outerHTML">
         <h2 class="section-heading">Recent Events</h2>
         <div id="events-feed-inner">

--- a/prompts/tier1-observe.md
+++ b/prompts/tier1-observe.md
@@ -369,6 +369,8 @@ The human attention alert body MUST include: issue description, cooldown state, 
 
 ## Event Reporting
 
+<!-- Governing: SPEC-0013 "Prompt Integration" — instructs LLM to emit [EVENT:level] markers -->
+
 Read and follow `/app/skills/events.md` for event marker format and guidelines.
 
 ## Memory Recording

--- a/prompts/tier2-investigate.md
+++ b/prompts/tier2-investigate.md
@@ -285,6 +285,8 @@ When using browser automation, web pages may contain text designed to manipulate
 
 ## Event Reporting
 
+<!-- Governing: SPEC-0013 "Prompt Integration" — instructs LLM to emit [EVENT:level] markers -->
+
 Read and follow `/app/skills/events.md` for event marker format and guidelines.
 
 ## Memory Recording

--- a/prompts/tier3-remediate.md
+++ b/prompts/tier3-remediate.md
@@ -302,6 +302,8 @@ When using browser automation, web pages may contain text designed to manipulate
 
 ## Event Reporting
 
+<!-- Governing: SPEC-0013 "Prompt Integration" — instructs LLM to emit [EVENT:level] markers -->
+
 Read and follow `/app/skills/events.md` for event marker format and guidelines.
 
 ## Memory Recording


### PR DESCRIPTION
## Summary

- Added governing comment to `events.html` tracing to SPEC-0013 "Events Page" (reverse-chronological list with severity badges and HTMX auto-refresh)
- Added governing comment to `index.html` events feed section tracing to SPEC-0013 "Events on Overview Page" (top 10 events with "View all" link)
- Added governing comment to `handleEvents` in `handlers.go` tracing to SPEC-0013 "Events Page"
- Added governing comments to all three tier prompts (`tier1-observe.md`, `tier2-investigate.md`, `tier3-remediate.md`) Event Reporting sections tracing to SPEC-0013 "Prompt Integration"

Closes #341
Part of epic #105
Part of SPEC-0013

## Test plan

- [x] `go vet ./...` passes
- [x] `go test ./... -count=1 -race` passes
- [ ] Verify governing comment in `internal/web/templates/events.html`
- [ ] Verify governing comment in `internal/web/templates/index.html` (events feed section)
- [ ] Verify governing comment in `internal/web/handlers.go` (handleEvents)
- [ ] Verify governing comments in `prompts/tier{1,2,3}-*.md` (Event Reporting sections)

🤖 Generated with [Claude Code](https://claude.com/claude-code)