### PR TITLE
Supervisor Escalation Logic governing comments (SPEC-0016)

### DIFF
--- a/internal/session/manager.go
+++ b/internal/session/manager.go
@@ -103,6 +103,7 @@ func (m *Manager) runAdHoc(ctx context.Context, prompt string) {
 	m.runEscalationChain(ctx, "manual", &prompt)
 }
 
+// Governing: SPEC-0016 "Supervisor Escalation Logic" — controls all escalation decisions
 // runEscalationChain runs Tier 1 and escalates to higher tiers if the agent
 // writes a handoff file requesting it. promptOverride is used for ad-hoc
 // sessions where the first tier uses a custom prompt instead of the standard
@@ -134,6 +135,7 @@ func (m *Manager) runEscalationChain(ctx context.Context, trigger string, prompt
 	handoffContext := ""
 	currentTrigger := trigger
 
+	// Governing: SPEC-0016 "Supervisor Escalation Logic" — MaxTier enforces tier limit
 	for currentTier <= m.cfg.MaxTier {
 		model := tierModels[currentTier]
 		promptFile := tierPrompts[currentTier]
@@ -171,6 +173,7 @@ func (m *Manager) runEscalationChain(ctx context.Context, trigger string, prompt
 			break
 		}
 
+		// Governing: SPEC-0016 "Supervisor Escalation Logic" — dry-run prevents escalation
 		// Dry-run mode: don't actually escalate.
 		if m.cfg.DryRun && h.RecommendedTier >= 2 {
 			fmt.Printf("[%s] DRY RUN: would escalate to tier %d for services %v\n",
@@ -241,6 +244,7 @@ func (m *Manager) runTier(ctx context.Context, tier int, model string, promptFil
 	}
 	defer logFile.Close() //nolint:errcheck
 
+	// Governing: SPEC-0016 "Supervisor Escalation Logic" — session record with parent_session_id
 	// Insert session record into DB.
 	startedAt := time.Now().UTC().Format(time.RFC3339)
 	sess := &db.Session{


### PR DESCRIPTION
## Summary
- Adds SPEC-0016 governing comments to `internal/session/manager.go` tracing the supervisor escalation logic
- `runEscalationChain`: controls all escalation decisions (reads handoff, validates, spawns next tier)
- MaxTier enforcement: loop condition `currentTier <= m.cfg.MaxTier` plus `ValidateHandoff` tier limit check
- Dry-run prevention: `m.cfg.DryRun` suppresses escalation, logs, deletes handoff
- Session record: `parent_session_id` set for chain tracking in `runTier`

## Verification
- Confirmed `runEscalationChain` implements all supervisor scenarios from SPEC-0016:
  - Spawns Tier 2/3 from valid handoff with parent_session_id linking
  - Dry-run mode prevents escalation (line 176)
  - MaxTier limit enforced via loop condition and ValidateHandoff
  - No handoff = no escalation (line 160-163)
  - Handoff context serialized via `buildHandoffContext` and injected via `--append-system-prompt`
- All tests pass (`go test ./... -count=1 -race`)

Closes #352
Part of epic #90
Part of SPEC-0016

## Test plan
- [x] `go vet ./...` passes
- [x] `go test ./... -count=1 -race` passes
- [x] Governing comments reference correct SPEC-0016 requirement name

🤖 Generated with [Claude Code](https://claude.com/claude-code)