### PR TITLE
Add governing comments for SPEC-0015 Memory Marker Format & Parsing

### DIFF
--- a/internal/session/manager.go
+++ b/internal/session/manager.go
@@ -821,6 +821,7 @@ func parseEventMarkers(text string) []parsedEvent {
 
 // --- Memory markers ---
 
+// Governing: SPEC-0015 "Memory Marker Regex" — pattern for [MEMORY:category] and [MEMORY:category:service]
 // memoryMarkerRe matches [MEMORY:category] or [MEMORY:category:service] markers in assistant text.
 var memoryMarkerRe = regexp.MustCompile(`\[MEMORY:([a-z]+)(?::([a-zA-Z0-9_-]+))?\]\s*(.+)`)
 
@@ -830,6 +831,7 @@ type parsedMemory struct {
 	Observation string
 }
 
+// Governing: SPEC-0015 "Memory Marker Format" — parses [MEMORY:category:service] from assistant text blocks
 // parseMemoryMarkers scans text for memory markers and returns parsed memories.
 func parseMemoryMarkers(text string) []parsedMemory {
 	var memories []parsedMemory

--- a/prompts/tier1-observe.md
+++ b/prompts/tier1-observe.md
@@ -255,6 +255,7 @@ Read and follow `/app/skills/events.md` for event marker format and guidelines.
 
 ## Memory Recording
 
+<!-- Governing: SPEC-0015 "Prompt Integration for Memory Markers" — instructs LLM to emit [MEMORY:category:service] markers -->
 Read and follow `/app/skills/memories.md` for memory marker format, categories, and guidelines.
 
 ## Output Format

--- a/prompts/tier2-investigate.md
+++ b/prompts/tier2-investigate.md
@@ -249,6 +249,7 @@ Read and follow `/app/skills/events.md` for event marker format and guidelines.
 
 ## Memory Recording
 
+<!-- Governing: SPEC-0015 "Prompt Integration for Memory Markers" — instructs LLM to emit [MEMORY:category:service] markers -->
 Read and follow `/app/skills/memories.md` for memory marker format, categories, and guidelines.
 
 ## Cooldown Tracking

--- a/prompts/tier3-remediate.md
+++ b/prompts/tier3-remediate.md
@@ -263,6 +263,7 @@ Read and follow `/app/skills/events.md` for event marker format and guidelines.
 
 ## Memory Recording
 
+<!-- Governing: SPEC-0015 "Prompt Integration for Memory Markers" — instructs LLM to emit [MEMORY:category:service] markers -->
 Read and follow `/app/skills/memories.md` for memory marker format, categories, and guidelines.
 
 ## Cooldown Tracking


### PR DESCRIPTION
## Summary
- Adds governing comments tracing memory marker implementation back to SPEC-0015 requirements
- `memoryMarkerRe` regex annotated with SPEC-0015 "Memory Marker Regex"
- `parseMemoryMarkers` function annotated with SPEC-0015 "Memory Marker Format"
- Memory Recording sections in tier1-observe.md, tier2-investigate.md, tier3-remediate.md annotated with SPEC-0015 "Prompt Integration for Memory Markers"

Closes #347 / Part of epic #8 / Part of SPEC-0015

## Test plan
- [x] `go vet ./...` passes
- [x] `go test ./... -count=1 -race` passes
- [x] Governing comments reference correct spec requirements

🤖 Generated with [Claude Code](https://claude.com/claude-code)