### PR TITLE
Add governing comments for SPEC-0015 memory storage

### DIFF
--- a/internal/db/migrations/00006_memories.sql
+++ b/internal/db/migrations/00006_memories.sql
@@ -1,3 +1,4 @@
+-- Governing: SPEC-0015 REQ "Memories Table Schema" (id, service, category, observation, confidence, active, created_at, updated_at, session_id, tier)
 -- +goose Up
 CREATE TABLE memories (
     id INTEGER PRIMARY KEY AUTOINCREMENT,

--- a/internal/session/manager.go
+++ b/internal/session/manager.go
@@ -848,6 +848,7 @@ func parseEventMarkers(text string) []parsedEvent {
 // --- Memory markers ---
 
 // Governing: SPEC-0015 "Memory Marker Regex" — pattern for [MEMORY:category] and [MEMORY:category:service]
+// Governing: SPEC-0015 REQ "Memory Categories" (timing, dependency, behavior, remediation, maintenance)
 // memoryMarkerRe matches [MEMORY:category] or [MEMORY:category:service] markers in assistant text.
 var memoryMarkerRe = regexp.MustCompile(`\[MEMORY:([a-z]+)(?::([a-zA-Z0-9_-]+))?\]\s*(.+)`)
 


### PR DESCRIPTION
## Summary
- Adds `-- Governing: SPEC-0015 REQ "Memories Table Schema"` to `internal/db/migrations/00006_memories.sql`
- Adds `// Governing: SPEC-0015 REQ "Memory Marker Regex" and REQ "Memory Categories"` to `internal/session/manager.go`

Closes #346 / Part of epic #8 / Part of SPEC-0015

## Test plan
- [x] `go vet ./...` passes
- [x] `go test ./... -count=1 -race` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)