### PR TITLE
Add governing comments for SPEC-0015 prompt injection & token budget

### DIFF
--- a/internal/session/manager.go
+++ b/internal/session/manager.go
@@ -267,6 +267,7 @@ func (m *Manager) runTier(ctx context.Context, tier int, model string, promptFil
 	}
 
 	// Build environment context string.
+	// Governing: SPEC-0015 REQ "Prompt Injection via buildMemoryContext" (memory context appended to --append-system-prompt)
 	envCtx := m.buildEnvContext()
 	if memCtx := m.buildMemoryContext(); memCtx != "" {
 		envCtx += "\n\n" + memCtx
@@ -1024,6 +1025,8 @@ func (m *Manager) insertCooldown(sessionID int64, tier int, pc parsedCooldown) {
 	}
 }
 
+// Governing: SPEC-0015 REQ "Token Budget Enforcement" (2000-token default, chars/4 estimation)
+// Governing: SPEC-0015 REQ "Memory Context Format" (grouped by service, category tag, confidence score)
 // buildMemoryContext queries active memories and formats them as a structured
 // markdown block for injection into the system prompt. It respects the
 // configured MemoryBudget (estimated as characters / 4).


### PR DESCRIPTION
## Summary
- Adds `// Governing: SPEC-0015 REQ "Prompt Injection via buildMemoryContext"` at the memory context injection site in `runTier()`
- Adds `// Governing: SPEC-0015 REQ "Token Budget Enforcement"` and `// Governing: SPEC-0015 REQ "Memory Context Format"` on `buildMemoryContext()`

Closes #349 / Part of epic #8 / Part of SPEC-0015

## Test plan
- [x] `go vet ./...` passes
- [x] `go test ./... -count=1 -race` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)