### PR TITLE
Add governing comments for SPEC-0015 Confidence & Lifecycle

### DIFF
--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -579,6 +579,7 @@ func (d *DB) GetMemory(id int64) (*Memory, error) {
 	return m, nil
 }
 
+// Governing: SPEC-0015 "Confidence Scoring" — confidence updates for reinforcement, contradiction, and operator edits
 // UpdateMemory updates a memory's observation, confidence, and active flag.
 func (d *DB) UpdateMemory(id int64, observation string, confidence float64, active bool) error {
 	_, err := d.conn.Exec(
@@ -662,6 +663,7 @@ func (d *DB) GetActiveMemories(limit int) ([]Memory, error) {
 	return memories, rows.Err()
 }
 
+// Governing: SPEC-0015 "Memory Reinforcement", "Memory Contradiction" — finds match for reinforce/contradict logic
 // FindSimilarMemory finds an existing memory matching the given service and category.
 func (d *DB) FindSimilarMemory(service *string, category string) (*Memory, error) {
 	var query string
@@ -690,6 +692,7 @@ func (d *DB) FindSimilarMemory(service *string, category string) (*Memory, error
 	return m, nil
 }
 
+// Governing: SPEC-0015 "Staleness Decay" — reduces confidence after grace period, deactivates below 0.3
 // DecayStaleMemories reduces confidence for memories not updated within graceDays,
 // then deactivates any that fall below 0.3.
 func (d *DB) DecayStaleMemories(graceDays int, decayRate float64) error {

--- a/internal/session/manager.go
+++ b/internal/session/manager.go
@@ -108,6 +108,7 @@ func (m *Manager) runAdHoc(ctx context.Context, prompt string) {
 // sessions where the first tier uses a custom prompt instead of the standard
 // prompt file.
 func (m *Manager) runEscalationChain(ctx context.Context, trigger string, promptOverride *string) {
+	// Governing: SPEC-0015 "Staleness Decay" — 0.1/week after 30-day grace, deactivate below 0.3
 	// Decay stale memories before each escalation chain.
 	if err := m.db.DecayStaleMemories(30, 0.1); err != nil {
 		fmt.Fprintf(os.Stderr, "decay stale memories: %v\n", err)
@@ -950,6 +951,7 @@ func (m *Manager) buildEnvContext() string {
 	return ctx
 }
 
+// Governing: SPEC-0015 "Confidence Scoring", "Memory Reinforcement", "Memory Contradiction" — default 0.7, +0.1 reinforce, -0.1 contradict
 // upsertMemory handles the insert-or-update logic for a parsed memory marker.
 // If a similar memory exists (same service + category), it either reinforces
 // (increases confidence) or contradicts (decreases old, inserts new).


### PR DESCRIPTION
## Summary
- Adds governing comments tracing confidence and lifecycle implementation back to SPEC-0015 requirements
- `upsertMemory` in manager.go annotated with SPEC-0015 "Confidence Scoring", "Memory Reinforcement", "Memory Contradiction"
- `DecayStaleMemories` call in manager.go and db.go annotated with SPEC-0015 "Staleness Decay"
- `FindSimilarMemory` in db.go annotated with SPEC-0015 "Memory Reinforcement", "Memory Contradiction"
- `UpdateMemory` in db.go annotated with SPEC-0015 "Confidence Scoring"

Closes #348 / Part of epic #8 / Part of SPEC-0015

## Test plan
- [x] `go vet ./...` passes
- [x] `go test ./... -count=1 -race` passes
- [x] Governing comments reference correct spec requirements

🤖 Generated with [Claude Code](https://claude.com/claude-code)