### PR TITLE
Add governing comments for database & chain tracking (SPEC-0016)

### DIFF
--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -34,7 +34,7 @@ type Session struct {
 	DurationMs *int64
 	Trigger         string  // "scheduled" or "manual"
 	PromptText      *string // custom prompt text for ad-hoc sessions
-	ParentSessionID *int64  // links to parent session for escalation chains
+	ParentSessionID *int64  // Governing: SPEC-0016 REQ "Database Schema for Escalation Chains" — links to parent session
 	Summary         *string // LLM-generated summary of session response — Governing: SPEC-0021 REQ "Summary Persistence"
 }
 
@@ -187,6 +187,7 @@ func (d *DB) UpdateSessionStatus(id int64, status string) error {
 }
 
 // UpdateSessionResult stores the final response and metadata from a completed session.
+// Governing: SPEC-0016 REQ "Per-Tier Cost Attribution" — each tier records cost_usd, num_turns, duration_ms independently
 func (d *DB) UpdateSessionResult(id int64, response string, costUSD float64, numTurns int, durationMs int64) error {
 	_, err := d.conn.Exec(
 		`UPDATE sessions SET response = ?, cost_usd = ?, num_turns = ?, duration_ms = ? WHERE id = ?`,
@@ -497,6 +498,7 @@ func (d *DB) LatestSession() (*Session, error) {
 
 // GetEscalationChain walks parent_session_id links from the given session
 // to the root, then returns the chain ordered from root to leaf.
+// Governing: SPEC-0016 REQ "Database Schema for Escalation Chains" — full chain queryable
 func (d *DB) GetEscalationChain(sessionID int64) ([]Session, error) {
 	rows, err := d.conn.Query(`
 		WITH RECURSIVE chain(id) AS (
@@ -526,6 +528,7 @@ func (d *DB) GetEscalationChain(sessionID int64) ([]Session, error) {
 }
 
 // GetChildSessions returns direct child sessions of the given session.
+// Governing: SPEC-0016 REQ "Dashboard Escalation Chain Display" — child link for session detail
 func (d *DB) GetChildSessions(sessionID int64) ([]Session, error) {
 	rows, err := d.conn.Query(
 		`SELECT `+sessionColumns+` FROM sessions WHERE parent_session_id = ? ORDER BY id ASC`, sessionID,

--- a/internal/db/migrations/00005_escalation_chain.sql
+++ b/internal/db/migrations/00005_escalation_chain.sql
@@ -1,3 +1,5 @@
+-- Governing: SPEC-0016 REQ "Database Schema for Escalation Chains"
+
 -- +goose Up
 ALTER TABLE sessions ADD COLUMN parent_session_id INTEGER REFERENCES sessions(id);
 CREATE INDEX idx_sessions_parent ON sessions(parent_session_id);

--- a/internal/session/manager.go
+++ b/internal/session/manager.go
@@ -242,6 +242,8 @@ func (m *Manager) runTier(ctx context.Context, tier int, model string, promptFil
 	defer logFile.Close() //nolint:errcheck
 
 	// Insert session record into DB.
+	// Governing: SPEC-0016 REQ "Per-Tier Cost Attribution" — each tier gets its own session record
+	// Governing: SPEC-0016 REQ "Database Schema for Escalation Chains" — parent_session_id links chain
 	startedAt := time.Now().UTC().Format(time.RFC3339)
 	sess := &db.Session{
 		Tier:            tier,


### PR DESCRIPTION
## Summary
- Added governing comments to `internal/db/db.go` tracing `ParentSessionID`, `GetEscalationChain`, `GetChildSessions`, and `UpdateSessionResult` back to SPEC-0016 requirements
- Added governing comment to migration `00005_escalation_chain.sql` referencing SPEC-0016 REQ "Database Schema for Escalation Chains"
- Added governing comments to `internal/session/manager.go` session record creation for per-tier cost attribution and chain linking

Closes #353 / Part of SPEC-0016

## Test plan
- [x] All existing tests pass (`go test ./... -count=1 -race`)
- [x] `go vet ./...` passes
- [x] No functional changes — comments only

🤖 Generated with [Claude Code](https://claude.com/claude-code)