### PR TITLE
Add governing comments for SPEC-0015 Dashboard Memory Management

### DIFF
--- a/internal/web/handlers.go
+++ b/internal/web/handlers.go
@@ -345,6 +345,7 @@ func (s *Server) handleCooldowns(w http.ResponseWriter, r *http.Request) {
 	s.render(w, r, "cooldowns.html", data)
 }
 
+// Governing: SPEC-0015 "Dashboard Memories Page" — /memories with service/category filters and HTMX polling
 // handleMemories renders the memories list with optional filters.
 func (s *Server) handleMemories(w http.ResponseWriter, r *http.Request) {
 	var serviceFilter *string
@@ -381,6 +382,7 @@ func (s *Server) handleMemories(w http.ResponseWriter, r *http.Request) {
 	s.render(w, r, "memories.html", data)
 }
 
+// Governing: SPEC-0015 "Dashboard Memory CRUD" — operator creates memories manually (session_id=NULL)
 // handleMemoryCreate handles POST /memories to create a new memory.
 func (s *Server) handleMemoryCreate(w http.ResponseWriter, r *http.Request) {
 	if err := r.ParseForm(); err != nil {
@@ -428,6 +430,7 @@ func (s *Server) handleMemoryCreate(w http.ResponseWriter, r *http.Request) {
 	http.Redirect(w, r, "/memories", http.StatusSeeOther)
 }
 
+// Governing: SPEC-0015 "Dashboard Memory CRUD" — operator edits observation, confidence, active status
 // handleMemoryUpdate handles POST /memories/{id}/update.
 func (s *Server) handleMemoryUpdate(w http.ResponseWriter, r *http.Request) {
 	idStr := r.PathValue("id")
@@ -462,6 +465,7 @@ func (s *Server) handleMemoryUpdate(w http.ResponseWriter, r *http.Request) {
 	http.Redirect(w, r, "/memories", http.StatusSeeOther)
 }
 
+// Governing: SPEC-0015 "Dashboard Memory CRUD" — operator permanently deletes a memory
 // handleMemoryDelete handles POST /memories/{id}/delete.
 func (s *Server) handleMemoryDelete(w http.ResponseWriter, r *http.Request) {
 	idStr := r.PathValue("id")

--- a/internal/web/templates/layout.html
+++ b/internal/web/templates/layout.html
@@ -46,6 +46,7 @@
                     </a>
                 </li>
                 <li>
+                    {{/* Governing: SPEC-0015 "Dashboard Memories Page" — sidebar nav between Events and Cooldowns */}}
                     <a href="/memories"
                        class="nav-link{{if eq .Page "memories.html"}} nav-active{{end}}"
                        hx-get="/memories" hx-target="#main" hx-push-url="true">

--- a/internal/web/templates/memories.html
+++ b/internal/web/templates/memories.html
@@ -1,4 +1,5 @@
 {{define "memories.html"}}
+{{/* Governing: SPEC-0015 "Dashboard Memories Page", "Dashboard Memory CRUD", "Inactive Memory Handling" */}}
 <div class="max-w-6xl">
     <h1 class="text-2xl font-semibold mb-6">Memories</h1>
 


### PR DESCRIPTION
## Summary
- Adds governing comments tracing dashboard memory management implementation back to SPEC-0015 requirements
- `handleMemories` in handlers.go annotated with SPEC-0015 "Dashboard Memories Page" (service/category filters)
- `handleMemoryCreate`, `handleMemoryUpdate`, `handleMemoryDelete` annotated with SPEC-0015 "Dashboard Memory CRUD"
- `memories.html` template annotated with SPEC-0015 "Dashboard Memories Page", "Dashboard Memory CRUD", "Inactive Memory Handling"
- `layout.html` sidebar nav link annotated with SPEC-0015 "Dashboard Memories Page" (positioned between Events and Cooldowns)

Closes #350 / Part of epic #8 / Part of SPEC-0015

## Test plan
- [x] `go vet ./...` passes
- [x] `go test ./... -count=1 -race` passes
- [x] Governing comments reference correct spec requirements

🤖 Generated with [Claude Code](https://claude.com/claude-code)