### PR TITLE
Add governing comments for SPEC-0017 Session Endpoints

### DIFF
--- a/internal/web/api_handlers.go
+++ b/internal/web/api_handlers.go
@@ -62,6 +62,7 @@ func (s *Server) handleAPIHealth(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, http.StatusOK, map[string]string{"status": "ok"})
 }
 
+// Governing: SPEC-0017 REQ-3 "Sessions List Endpoint" — GET /api/v1/sessions with limit/offset pagination
 // handleAPIListSessions returns a paginated list of sessions.
 func (s *Server) handleAPIListSessions(w http.ResponseWriter, r *http.Request) {
 	limit, offset, err := parseLimitOffset(r, 50)
@@ -80,6 +81,7 @@ func (s *Server) handleAPIListSessions(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, http.StatusOK, APISessionsResponse{Sessions: toAPISessions(sessions)})
 }
 
+// Governing: SPEC-0017 REQ-4 "Session Detail Endpoint" — GET /api/v1/sessions/{id} with chain details
 // handleAPIGetSession returns a single session with escalation chain details.
 func (s *Server) handleAPIGetSession(w http.ResponseWriter, r *http.Request) {
 	id, err := strconv.ParseInt(r.PathValue("id"), 10, 64)
@@ -155,6 +157,7 @@ func (s *Server) handleAPIGetSession(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, http.StatusOK, apiSess)
 }
 
+// Governing: SPEC-0017 REQ-5 "Session Trigger Endpoint" — POST /api/v1/sessions/trigger with JSON body
 // handleAPITriggerSession triggers an ad-hoc session from a JSON request body.
 func (s *Server) handleAPITriggerSession(w http.ResponseWriter, r *http.Request) {
 	if !requireJSON(w, r) {

--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -327,6 +327,7 @@ func (s *Server) registerRoutes() {
 
 	// API v1
 	s.mux.HandleFunc("GET /api/v1/health", s.handleAPIHealth)
+	// Governing: SPEC-0017 REQ-3, REQ-4, REQ-5 — session list, detail, and trigger endpoints
 	s.mux.HandleFunc("GET /api/v1/sessions", s.handleAPIListSessions)
 	s.mux.HandleFunc("GET /api/v1/sessions/{id}", s.handleAPIGetSession)
 	s.mux.HandleFunc("POST /api/v1/sessions/trigger", s.handleAPITriggerSession)


### PR DESCRIPTION
## Summary
- Adds governing comments tracing REST API session endpoints back to SPEC-0017 requirements
- `handleAPIListSessions`: SPEC-0017 REQ-3 "Sessions List Endpoint" (GET /api/v1/sessions with pagination)
- `handleAPIGetSession`: SPEC-0017 REQ-4 "Session Detail Endpoint" (GET /api/v1/sessions/{id} with chain details)
- `handleAPITriggerSession`: SPEC-0017 REQ-5 "Session Trigger Endpoint" (POST /api/v1/sessions/trigger with JSON body)
- Route registrations in server.go annotated with SPEC-0017 REQ-3, REQ-4, REQ-5

Closes #356 / Part of epic #150 / Part of SPEC-0017

## Test plan
- [x] `go vet ./...` passes
- [x] `go test ./... -count=1 -race` passes
- [x] Governing comments reference correct spec requirements

🤖 Generated with [Claude Code](https://claude.com/claude-code)