### PR TITLE
Add governing comments for SPEC-0017 Events, Memories & Cooldowns Endpoints

### DIFF
--- a/internal/web/api_handlers.go
+++ b/internal/web/api_handlers.go
@@ -188,6 +188,7 @@ func (s *Server) handleAPITriggerSession(w http.ResponseWriter, r *http.Request)
 	writeJSON(w, http.StatusCreated, toAPISession(*sess))
 }
 
+// Governing: SPEC-0017 REQ-6 "Events List Endpoint" — GET /api/v1/events with level/service filters
 // handleAPIListEvents returns a paginated, filterable list of events.
 func (s *Server) handleAPIListEvents(w http.ResponseWriter, r *http.Request) {
 	limit, offset, err := parseLimitOffset(r, 100)
@@ -215,6 +216,7 @@ func (s *Server) handleAPIListEvents(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, http.StatusOK, APIEventsResponse{Events: toAPIEvents(events)})
 }
 
+// Governing: SPEC-0017 REQ-7 "Memories List Endpoint" — GET /api/v1/memories with service/category filters
 // handleAPIListMemories returns a paginated, filterable list of memories.
 func (s *Server) handleAPIListMemories(w http.ResponseWriter, r *http.Request) {
 	limit, offset, err := parseLimitOffset(r, 200)
@@ -242,6 +244,7 @@ func (s *Server) handleAPIListMemories(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, http.StatusOK, APIMemoriesResponse{Memories: toAPIMemories(memories)})
 }
 
+// Governing: SPEC-0017 REQ-8 "Memory Create Endpoint" — POST /api/v1/memories with JSON body
 // handleAPICreateMemory creates a new memory from a JSON request body.
 func (s *Server) handleAPICreateMemory(w http.ResponseWriter, r *http.Request) {
 	if !requireJSON(w, r) {
@@ -292,6 +295,7 @@ func (s *Server) handleAPICreateMemory(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, http.StatusCreated, toAPIMemory(*created))
 }
 
+// Governing: SPEC-0017 REQ-9 "Memory Update Endpoint" — PUT /api/v1/memories/{id} with JSON body
 // handleAPIUpdateMemory updates a memory from a JSON request body.
 func (s *Server) handleAPIUpdateMemory(w http.ResponseWriter, r *http.Request) {
 	if !requireJSON(w, r) {
@@ -349,6 +353,7 @@ func (s *Server) handleAPIUpdateMemory(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, http.StatusOK, toAPIMemory(*updated))
 }
 
+// Governing: SPEC-0017 REQ-10 "Memory Delete Endpoint" — DELETE /api/v1/memories/{id}
 // handleAPIDeleteMemory deletes a memory by ID.
 func (s *Server) handleAPIDeleteMemory(w http.ResponseWriter, r *http.Request) {
 	id, err := strconv.ParseInt(r.PathValue("id"), 10, 64)
@@ -377,6 +382,7 @@ func (s *Server) handleAPIDeleteMemory(w http.ResponseWriter, r *http.Request) {
 	w.WriteHeader(http.StatusNoContent)
 }
 
+// Governing: SPEC-0017 REQ-11 "Cooldowns List Endpoint" — GET /api/v1/cooldowns
 // handleAPIListCooldowns returns cooldown action summaries for the last 24 hours.
 func (s *Server) handleAPIListCooldowns(w http.ResponseWriter, r *http.Request) {
 	cooldowns, err := s.db.ListRecentCooldowns(24 * time.Hour)

--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -330,6 +330,7 @@ func (s *Server) registerRoutes() {
 	s.mux.HandleFunc("GET /api/v1/sessions", s.handleAPIListSessions)
 	s.mux.HandleFunc("GET /api/v1/sessions/{id}", s.handleAPIGetSession)
 	s.mux.HandleFunc("POST /api/v1/sessions/trigger", s.handleAPITriggerSession)
+	// Governing: SPEC-0017 REQ-6 through REQ-11 — events, memories CRUD, and cooldowns endpoints
 	s.mux.HandleFunc("GET /api/v1/events", s.handleAPIListEvents)
 	s.mux.HandleFunc("GET /api/v1/memories", s.handleAPIListMemories)
 	s.mux.HandleFunc("POST /api/v1/memories", s.handleAPICreateMemory)


### PR DESCRIPTION
## Summary
- Adds governing comments tracing REST API endpoints back to SPEC-0017 requirements
- `handleAPIListEvents`: REQ-6 "Events List Endpoint"
- `handleAPIListMemories`: REQ-7 "Memories List Endpoint"
- `handleAPICreateMemory`: REQ-8 "Memory Create Endpoint"
- `handleAPIUpdateMemory`: REQ-9 "Memory Update Endpoint"
- `handleAPIDeleteMemory`: REQ-10 "Memory Delete Endpoint"
- `handleAPIListCooldowns`: REQ-11 "Cooldowns List Endpoint"
- Route registrations in server.go annotated with REQ-6 through REQ-11

Closes #357 / Part of epic #150 / Part of SPEC-0017

## Test plan
- [x] `go vet ./...` passes
- [x] `go test ./... -count=1 -race` passes
- [x] Governing comments reference correct spec requirements

🤖 Generated with [Claude Code](https://claude.com/claude-code)