### PR TITLE
Add governing comments for SPEC-0017 Config & Health Endpoints

### DIFF
--- a/internal/web/api_handlers.go
+++ b/internal/web/api_handlers.go
@@ -57,6 +57,7 @@ func parseLimitOffset(r *http.Request, defaultLimit int) (limit, offset int, err
 
 // --- API Handlers ---
 
+// Governing: SPEC-0017 REQ-14 "Health Endpoint" — GET /api/v1/health
 // handleAPIHealth returns a simple health check response.
 func (s *Server) handleAPIHealth(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, http.StatusOK, map[string]string{"status": "ok"})
@@ -389,6 +390,7 @@ func (s *Server) handleAPIListCooldowns(w http.ResponseWriter, r *http.Request) 
 	writeJSON(w, http.StatusOK, APICooldownsResponse{Cooldowns: toAPICooldowns(cooldowns)})
 }
 
+// Governing: SPEC-0017 REQ-12 "Config Get Endpoint" — GET /api/v1/config
 // handleAPIGetConfig returns the current runtime configuration.
 func (s *Server) handleAPIGetConfig(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, http.StatusOK, APIConfig{
@@ -405,6 +407,7 @@ func (s *Server) handleAPIGetConfig(w http.ResponseWriter, r *http.Request) {
 	})
 }
 
+// Governing: SPEC-0017 REQ-13 "Config Update Endpoint" — PUT /api/v1/config (partial update)
 // handleAPIUpdateConfig applies partial configuration updates from a JSON body.
 func (s *Server) handleAPIUpdateConfig(w http.ResponseWriter, r *http.Request) {
 	if !requireJSON(w, r) {

--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -326,6 +326,7 @@ func (s *Server) registerRoutes() {
 	s.mux.HandleFunc("POST /sessions/trigger", s.handleTriggerSession)
 
 	// API v1
+	// Governing: SPEC-0017 REQ-14 "Health Endpoint"
 	s.mux.HandleFunc("GET /api/v1/health", s.handleAPIHealth)
 	s.mux.HandleFunc("GET /api/v1/sessions", s.handleAPIListSessions)
 	s.mux.HandleFunc("GET /api/v1/sessions/{id}", s.handleAPIGetSession)
@@ -336,6 +337,7 @@ func (s *Server) registerRoutes() {
 	s.mux.HandleFunc("PUT /api/v1/memories/{id}", s.handleAPIUpdateMemory)
 	s.mux.HandleFunc("DELETE /api/v1/memories/{id}", s.handleAPIDeleteMemory)
 	s.mux.HandleFunc("GET /api/v1/cooldowns", s.handleAPIListCooldowns)
+	// Governing: SPEC-0017 REQ-12 "Config Get Endpoint", REQ-13 "Config Update Endpoint"
 	s.mux.HandleFunc("GET /api/v1/config", s.handleAPIGetConfig)
 	s.mux.HandleFunc("PUT /api/v1/config", s.handleAPIUpdateConfig)
 	s.mux.HandleFunc("POST /api/v1/prs", s.handleAPICreatePR)


### PR DESCRIPTION
## Summary
- Adds governing comments tracing REST API config and health endpoints back to SPEC-0017 requirements
- `handleAPIHealth`: REQ-14 "Health Endpoint"
- `handleAPIGetConfig`: REQ-12 "Config Get Endpoint"
- `handleAPIUpdateConfig`: REQ-13 "Config Update Endpoint"
- Route registrations in server.go annotated with REQ-12, REQ-13, REQ-14

Closes #358 / Part of epic #150 / Part of SPEC-0017

## Test plan
- [x] `go vet ./...` passes
- [x] `go test ./... -count=1 -race` passes
- [x] Governing comments reference correct spec requirements

🤖 Generated with [Claude Code](https://claude.com/claude-code)