### PR TITLE
Add governing comments for SPEC-0017 OpenAPI & Swagger UI

### DIFF
--- a/api/embed.go
+++ b/api/embed.go
@@ -2,8 +2,12 @@ package api
 
 import "embed"
 
+// Governing: SPEC-0017 REQ-15 "OpenAPI Specification File" — embedded OpenAPI 3.1 spec served at /api/openapi.yaml
+//
 //go:embed openapi.yaml
 var OpenAPISpec []byte
 
+// Governing: SPEC-0017 REQ-16 "Swagger UI" — embedded Swagger UI assets served at /api/docs/
+//
 //go:embed swagger-ui/*
 var SwaggerUIFS embed.FS

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -1,3 +1,4 @@
+# Governing: SPEC-0017 REQ-15 "OpenAPI Specification File", REQ-19 "Backward Compatibility"
 openapi: "3.1.0"
 info:
   title: Claude Ops API

--- a/api/swagger-ui/index.html
+++ b/api/swagger-ui/index.html
@@ -1,3 +1,4 @@
+<!-- Governing: SPEC-0017 REQ-16 "Swagger UI" — interactive API documentation at /api/docs/ -->
 <!DOCTYPE html>
 <html lang="en">
 <head>

--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -333,7 +333,7 @@ func (s *Server) registerRoutes() {
 	// API v1
 	// Governing: SPEC-0017 REQ-1 "API Route Registration" — all /api/v1/ routes on same ServeMux
 	// Governing: SPEC-0017 REQ-14 "Health Endpoint"
-	// Governing: SPEC-0017 REQ-19 "Backward Compatibility" — HTML routes above remain unchanged
+	// Governing: SPEC-0017 REQ-19 "Backward Compatibility" — HTML routes above remain unchanged; all endpoints under /api/v1 prefix
 	s.mux.HandleFunc("GET /api/v1/health", s.handleAPIHealth)
 	// Governing: SPEC-0017 REQ-3, REQ-4, REQ-5 — session list, detail, and trigger endpoints
 	s.mux.HandleFunc("GET /api/v1/sessions", s.handleAPIListSessions)
@@ -352,7 +352,7 @@ func (s *Server) registerRoutes() {
 	s.mux.HandleFunc("POST /api/v1/prs", s.handleAPICreatePR)
 	s.mux.HandleFunc("GET /api/v1/prs", s.handleAPIListPRs)
 
-	// Governing: SPEC-0017 REQ-15 "OpenAPI Specification File" — embedded YAML at /api/openapi.yaml
+	// Governing: SPEC-0017 REQ-15 "OpenAPI Specification File" — embedded YAML at /api/openapi.yaml, REQ-16 "Swagger UI"
 	s.mux.HandleFunc("GET /api/openapi.yaml", s.handleOpenAPISpec)
 	// Governing: SPEC-0017 REQ-16 "Swagger UI" — embedded static assets at /api/docs/
 	swaggerSub, _ := fs.Sub(api.SwaggerUIFS, "swagger-ui")
@@ -393,6 +393,7 @@ func (s *Server) render(w http.ResponseWriter, r *http.Request, name string, dat
 	}
 }
 
+// Governing: SPEC-0017 REQ-15 "OpenAPI Specification File" — serves embedded openapi.yaml with YAML content type
 func (s *Server) handleOpenAPISpec(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "application/yaml")
 	_, _ = w.Write(api.OpenAPISpec)


### PR DESCRIPTION
## Summary
- Adds governing comments tracing SPEC-0017 REQ-15 (OpenAPI Specification File), REQ-16 (Swagger UI), and REQ-19 (Backward Compatibility) to their implementations
- Annotated files: `api/embed.go`, `api/openapi.yaml`, `api/swagger-ui/index.html`, `internal/web/server.go`

Closes #359 / Part of epic #150 / Part of SPEC-0017

## Test plan
- [x] `go vet ./...` passes
- [x] `go test ./... -count=1 -race` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)