### PR TITLE
Add SPEC-0014 governing comments for permission gate and auditing

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -148,7 +148,7 @@ Everything in Tier 1, plus:
 - Fix file ownership/permissions on known data paths
 - Clear tmp/cache directories
 - Update API keys via service REST APIs
-- Browser automation for credential rotation (via Chrome DevTools MCP)
+- Browser automation for credential rotation (via Chrome DevTools MCP) <!-- Governing: SPEC-0014 "Tier 2+ Permission Gate" -->
 - Send notifications via Apprise
 
 ### Tier 3 — Opus (Full Remediation)

--- a/internal/session/browser.go
+++ b/internal/session/browser.go
@@ -9,6 +9,7 @@ import (
 // Governing: SPEC-0014 REQ "Credential Injection via Environment Variables" (BROWSER_CRED_* env vars, Tier 2+ gate)
 // ResolveCredential looks up a BROWSER_CRED_* environment variable by name,
 // enforcing Tier 2+ permissions and the BROWSER_CRED_ prefix convention.
+// Governing: SPEC-0014 "Tier 2+ Permission Gate" — credential injection requires Tier 2+.
 func ResolveCredential(tier int, envKey string) (string, error) {
 	if tier < 2 {
 		return "", fmt.Errorf("browser credential injection requires Tier 2+")

--- a/internal/session/manager.go
+++ b/internal/session/manager.go
@@ -336,6 +336,7 @@ func (m *Manager) runTier(ctx context.Context, tier int, model string, promptFil
 		var lineNum int
 		for scanner.Scan() {
 			// Governing: SPEC-0014 REQ "Log Redaction of Credential Values" — redact before any output channel
+			// Governing: SPEC-0014 "Browser Automation Auditing" — redact credentials before logging/SSE.
 			raw := m.redactor.Redact(scanner.Text())
 			ts := time.Now().UTC()
 

--- a/internal/session/redaction.go
+++ b/internal/session/redaction.go
@@ -11,6 +11,7 @@ import (
 // RedactionFilter scans output for known credential values and replaces them
 // with [REDACTED:VAR_NAME] placeholders. It builds a replacement dictionary
 // from BROWSER_CRED_* environment variables at construction time.
+// Governing: SPEC-0014 "Browser Automation Auditing" — redact credential values from all output channels.
 type RedactionFilter struct {
 	replacements map[string]string // credential value -> "[REDACTED:VAR_NAME]"
 }

--- a/prompts/tier1-observe.md
+++ b/prompts/tier1-observe.md
@@ -268,6 +268,7 @@ Categorize each service:
 - **down** — service is unreachable or critical checks failed
 - **in_cooldown** — known issue, cooldown limits reached, waiting for human
 
+<!-- Governing: SPEC-0014 "Tier 2+ Permission Gate" — Tier 1 denied browser authentication -->
 ## Browser Automation
 
 Browser authentication is NOT permitted at Tier 1. You may check if a login page loads (unauthenticated navigation to allowed origins only), but you MUST NOT:

--- a/prompts/tier2-investigate.md
+++ b/prompts/tier2-investigate.md
@@ -247,6 +247,8 @@ When a remediation requires elevated privileges (write commands like `docker res
 
 Do NOT skip the issue silently. Do NOT escalate to a higher tier solely because of limited access — a higher tier does not grant more SSH access.
 
+<!-- Governing: SPEC-0014 "Tier 2+ Permission Gate" — Tier 2 permitted browser authentication -->
+<!-- Governing: SPEC-0014 "Browser Automation Auditing" — all actions logged with redacted credentials -->
 ## Browser Automation
 
 You may use Chrome DevTools MCP tools for authenticated browser automation against allowed origins.

--- a/prompts/tier3-remediate.md
+++ b/prompts/tier3-remediate.md
@@ -265,6 +265,8 @@ When a remediation requires elevated privileges (write commands like `docker res
 
 Do NOT skip the issue silently. Do NOT escalate further solely because of limited access — a higher tier does not grant more SSH access. This is the terminal tier; if you cannot fix the issue due to limited access, report it via Apprise and include the commands a human would need to run.
 
+<!-- Governing: SPEC-0014 "Tier 2+ Permission Gate" — Tier 3 permitted browser authentication -->
+<!-- Governing: SPEC-0014 "Browser Automation Auditing" — all actions logged with redacted credentials -->
 ## Browser Automation
 
 You may use Chrome DevTools MCP tools for authenticated browser automation against allowed origins.


### PR DESCRIPTION
## Summary

- Adds governing comments tracing SPEC-0014 requirements to their implementations:
  - **Tier 2+ Permission Gate**: 
    - `internal/session/browser.go:ResolveCredential()` — programmatic tier check (tier < 2 rejected)
    - `prompts/tier1-observe.md` — "Browser authentication is NOT permitted at Tier 1"
    - `prompts/tier2-investigate.md` and `prompts/tier3-remediate.md` — "Tier 2/3 permitted browser authentication"
    - `CLAUDE.md` — browser automation listed under Tier 2 permissions
  - **Browser Automation Auditing**:
    - `internal/session/redaction.go:RedactionFilter` — builds BROWSER_CRED_* redaction dictionary, replaces values in all output
    - `internal/session/manager.go` line 317 — redaction applied to every stream-json line before logging/SSE
    - `prompts/tier2-investigate.md` and `prompts/tier3-remediate.md` — auditing notes

## Test plan

- [x] `go vet ./...` passes
- [x] `go test ./... -count=1 -race` passes
- [ ] Verify governing comments are correctly placed next to the relevant implementation code

Closes #345
Part of epic #151
Part of SPEC-0014