### PR TITLE
Add governing comments for SPEC-0018 GitProvider interface

### DIFF
--- a/internal/gitprovider/gitea.go
+++ b/internal/gitprovider/gitea.go
@@ -12,6 +12,8 @@ import (
 	"time"
 )
 
+// Governing: SPEC-0018 REQ-3 "Gitea Provider Implementation" — GitProvider via Gitea v1 REST API
+//
 // GiteaProvider implements GitProvider for Gitea instances using the v1 REST API.
 type GiteaProvider struct {
 	baseURL string

--- a/internal/gitprovider/github.go
+++ b/internal/gitprovider/github.go
@@ -11,6 +11,8 @@ import (
 	"time"
 )
 
+// Governing: SPEC-0018 REQ-2 "GitHub Provider Implementation" — GitProvider via GitHub REST API
+//
 // GitHubProvider implements GitProvider using the GitHub REST API.
 type GitHubProvider struct {
 	token   string

--- a/internal/gitprovider/provider.go
+++ b/internal/gitprovider/provider.go
@@ -2,6 +2,8 @@ package gitprovider
 
 import "context"
 
+// Governing: SPEC-0018 REQ-1 "GitProvider Interface" — abstracts CreatePR, ListPRs, GetPRStatus across providers
+//
 // GitProvider abstracts git hosting operations for PR-based workflows.
 // Each implementation targets a specific platform (GitHub, Gitea, etc.).
 type GitProvider interface {


### PR DESCRIPTION
## Summary
- Adds governing comments tracing SPEC-0018 REQ-1 (GitProvider Interface), REQ-2 (GitHub Provider Implementation), and REQ-3 (Gitea Provider Implementation) to their implementations
- Annotated files: `internal/gitprovider/provider.go`, `internal/gitprovider/github.go`, `internal/gitprovider/gitea.go`

Closes #360 / Part of epic #219 / Part of SPEC-0018

## Test plan
- [x] `go vet ./...` passes
- [x] `go test ./... -count=1 -race` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)