### PR TITLE
Add governing comments for SPEC-0018 Provider Registry & Discovery

### DIFF
--- a/internal/gitprovider/disabled.go
+++ b/internal/gitprovider/disabled.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 )
 
+// Governing: SPEC-0018 REQ-13 "Environment Variable Configuration" — disabled state when config is missing
 // DisabledProvider implements GitProvider but returns an error on every
 // operation. It is used when a provider's required configuration (e.g.,
 // tokens) is missing, so the system can start without failing while still

--- a/internal/gitprovider/provider.go
+++ b/internal/gitprovider/provider.go
@@ -2,7 +2,7 @@ package gitprovider
 
 import "context"
 
-// Governing: SPEC-0018 REQ-1 "GitProvider Interface" — abstracts CreatePR, ListPRs, GetPRStatus across providers
+// Governing: SPEC-0018 REQ-1 "GitProvider Interface" — abstracts CreatePR, ListPRs, GetPRStatus across providers; six required methods in dedicated package
 //
 // GitProvider abstracts git hosting operations for PR-based workflows.
 // Each implementation targets a specific platform (GitHub, Gitea, etc.).
@@ -83,6 +83,7 @@ type PRSummary struct {
 	Files  []string // paths modified by the PR
 }
 
+// Governing: SPEC-0018 REQ-4 "Provider Registry and Discovery" — explicit declaration in CLAUDE-OPS.md manifest
 // Manifest holds the parsed Git Provider section from a repo's CLAUDE-OPS.md.
 type Manifest struct {
 	Provider   string // e.g., "github", "gitea"

--- a/internal/gitprovider/registry.go
+++ b/internal/gitprovider/registry.go
@@ -6,11 +6,13 @@ import (
 	"strings"
 )
 
+// Governing: SPEC-0018 REQ-4 "Provider Registry and Discovery" — maps provider names to implementations
 // Registry maps provider names to GitProvider implementations.
 type Registry struct {
 	providers map[string]GitProvider
 }
 
+// Governing: SPEC-0018 REQ-13 "Environment Variable Configuration" — registers from env vars, disabled when missing
 // NewRegistry creates a Registry and registers providers based on environment
 // variables. Providers whose required config is missing are registered in a
 // disabled state so the system always starts successfully.
@@ -48,6 +50,7 @@ func (r *Registry) Register(name string, provider GitProvider) {
 	r.providers[name] = provider
 }
 
+// Governing: SPEC-0018 REQ-4 "Provider Registry and Discovery" — manifest first, then URL inference
 // Resolve selects the appropriate provider for a repo. It checks the manifest
 // first (explicit declaration), then infers from the clone URL.
 func (r *Registry) Resolve(repo RepoRef, manifest *Manifest) (GitProvider, error) {
@@ -73,6 +76,7 @@ func (r *Registry) ResolveByName(name string) (GitProvider, error) {
 	return p, nil
 }
 
+// Governing: SPEC-0018 REQ-4 "Provider Registry and Discovery" — github.com -> GitHub, GITEA_URL host -> Gitea
 // inferProvider maps a clone URL to a provider name based on known domain patterns.
 func inferProvider(cloneURL string) string {
 	lower := strings.ToLower(cloneURL)


### PR DESCRIPTION
## Summary

- Adds governing comments to `internal/gitprovider/provider.go`, `internal/gitprovider/registry.go`, and `internal/gitprovider/disabled.go` tracing implementation back to SPEC-0018 requirements
- REQ-1 "GitProvider Interface": interface definition with six required methods
- REQ-4 "Provider Registry and Discovery": Registry struct, Resolve (manifest first, then URL inference), inferProvider (github.com -> GitHub, GITEA_URL host -> Gitea)
- REQ-13 "Environment Variable Configuration": NewRegistry env var initialization, DisabledProvider for missing config

Closes #361 / Part of SPEC-0018

## Test plan

- [x] `go vet ./...` passes
- [x] `go test ./... -count=1 -race` passes
- [ ] Verify governing comments reference correct SPEC-0018 requirement names

Generated with [Claude Code](https://claude.ai/code)