### PR TITLE
Add governing comments for SPEC-0018 branch naming and scope

### DIFF
--- a/internal/gitprovider/branch.go
+++ b/internal/gitprovider/branch.go
@@ -5,6 +5,8 @@ import (
 	"strings"
 )
 
+// Governing: SPEC-0018 REQ-5 "Branch Naming Convention" — claude-ops/{type}/{slug} format
+//
 // GenerateBranchName creates a branch name from the change type and title.
 // The format is claude-ops/{changeType}/{slug} where slug is the title
 // lowercased, non-alphanumeric characters replaced by hyphens, consecutive

--- a/internal/gitprovider/scope.go
+++ b/internal/gitprovider/scope.go
@@ -6,6 +6,8 @@ import (
 	"strings"
 )
 
+// Governing: SPEC-0018 REQ-6 "Allowed and Disallowed Change Scopes" — allowlist of agent-modifiable paths
+//
 // allowedPatterns lists the file path patterns the agent may propose changes to.
 var allowedPatterns = []string{
 	"checks/*.md",
@@ -16,6 +18,8 @@ var allowedPatterns = []string{
 	"CLAUDE-OPS.md",
 }
 
+// Governing: SPEC-0018 REQ-6 "Allowed and Disallowed Change Scopes" — denylist of protected paths
+//
 // deniedPatterns lists the file path patterns the agent must never modify.
 var deniedPatterns = []string{
 	"prompts/*.md",
@@ -28,6 +32,8 @@ var deniedPatterns = []string{
 	"*.env*",
 }
 
+// Governing: SPEC-0018 REQ-6 "Allowed and Disallowed Change Scopes" — validates all files against allow/deny lists
+//
 // ValidateScope checks that every file in the changeset is within the allowed
 // scope for agent-proposed changes. It returns an error describing the first
 // violation found.


### PR DESCRIPTION
## Summary
- Adds governing comments tracing SPEC-0018 REQ-5 (Branch Naming Convention) and REQ-6 (Allowed and Disallowed Change Scopes) to their implementations
- Annotated files: `internal/gitprovider/branch.go`, `internal/gitprovider/scope.go`

Closes #362 / Part of epic #219 / Part of SPEC-0018

## Test plan
- [x] `go vet ./...` passes
- [x] `go test ./... -count=1 -race` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)