### PR TITLE
Add governing comments for SPEC-0018 PR creation and workflow

### DIFF
--- a/internal/gitprovider/provider.go
+++ b/internal/gitprovider/provider.go
@@ -3,6 +3,7 @@ package gitprovider
 import "context"
 
 // Governing: SPEC-0018 REQ-1 "GitProvider Interface" — abstracts CreatePR, ListPRs, GetPRStatus across providers; six required methods in dedicated package
+// Governing: SPEC-0018 REQ-10 "Agent MUST NOT Merge Own PRs" — no MergePR method exposed
 //
 // GitProvider abstracts git hosting operations for PR-based workflows.
 // Each implementation targets a specific platform (GitHub, Gitea, etc.).

--- a/internal/web/api_handlers.go
+++ b/internal/web/api_handlers.go
@@ -508,6 +508,9 @@ func (s *Server) handleAPIUpdateConfig(w http.ResponseWriter, r *http.Request) {
 	})
 }
 
+// Governing: SPEC-0018 REQ-7 "PR Body Context Requirements", REQ-8 "Duplicate PR Prevention",
+//            REQ-10 "Agent MUST NOT Merge Own PRs", REQ-11 "Notification on PR Creation"
+//
 // handleAPICreatePR creates a branch, commits files, and opens a pull request.
 func (s *Server) handleAPICreatePR(w http.ResponseWriter, r *http.Request) {
 	if !s.cfg.PREnabled {
@@ -588,6 +591,7 @@ func (s *Server) handleAPICreatePR(w http.ResponseWriter, r *http.Request) {
 	})
 }
 
+// Governing: SPEC-0018 REQ-8 "Duplicate PR Prevention" — list open PRs by claude-ops label for overlap check
 // handleAPIListPRs lists open pull requests for a repository filtered by the claude-ops label.
 func (s *Server) handleAPIListPRs(w http.ResponseWriter, r *http.Request) {
 	owner := r.URL.Query().Get("repo_owner")

--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -349,6 +349,7 @@ func (s *Server) registerRoutes() {
 	// Governing: SPEC-0017 REQ-12 "Config Get Endpoint", REQ-13 "Config Update Endpoint"
 	s.mux.HandleFunc("GET /api/v1/config", s.handleAPIGetConfig)
 	s.mux.HandleFunc("PUT /api/v1/config", s.handleAPIUpdateConfig)
+	// Governing: SPEC-0018 REQ-7, REQ-8, REQ-10, REQ-11 — PR creation and listing endpoints
 	s.mux.HandleFunc("POST /api/v1/prs", s.handleAPICreatePR)
 	s.mux.HandleFunc("GET /api/v1/prs", s.handleAPIListPRs)
 


### PR DESCRIPTION
## Summary
- Adds governing comments tracing SPEC-0018 REQ-7 (PR Body Context), REQ-8 (Duplicate PR Prevention), REQ-10 (Agent MUST NOT Merge), and REQ-11 (Notification on PR Creation) to their implementations
- Annotated files: `internal/web/api_handlers.go`, `internal/web/server.go`, `internal/gitprovider/provider.go`

Closes #363 / Part of epic #219 / Part of SPEC-0018

## Test plan
- [x] `go vet ./...` passes
- [x] `go test ./... -count=1 -race` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)