### PR TITLE
Add governing comments for SPEC-0020 SSH probing and connection

### DIFF
--- a/skills/ssh-discovery.md
+++ b/skills/ssh-discovery.md
@@ -1,3 +1,5 @@
+<!-- Governing: SPEC-0020 "SSH Probing Order", "SSH Connection Parameters" — probes root, manifest user, common defaults with BatchMode=yes and 5s timeout -->
+
 # Skill: SSH Access Discovery
 
 Discover the SSH access method for each managed host at the start of every monitoring cycle, before any health checks run. The result is a host access map that all tiers use to construct SSH commands for the rest of the run.


### PR DESCRIPTION
## Summary
- Adds governing comments tracing SPEC-0020 SSH Probing Order and SSH Connection Parameters to their implementation
- Annotated file: `skills/ssh-discovery.md`

Closes #369 / Part of epic #94 / Part of SPEC-0020

## Test plan
- [x] `go vet ./...` passes
- [x] `go test ./... -count=1 -race` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)