### PR TITLE
Add governing comments for tier integration & dry run (SPEC-0018)

### DIFF
--- a/internal/gitprovider/tier.go
+++ b/internal/gitprovider/tier.go
@@ -5,6 +5,7 @@ import "fmt"
 // ValidateTier checks that the given permission tier is allowed to create a PR
 // with the specified file changes. Tier 1 agents cannot create PRs. Tier 2
 // agents are limited to 3 files per PR. Tier 3 agents have no file limit.
+// Governing: SPEC-0018 REQ-9 "Permission Tier Integration" — enforce tier gate at provider interface level.
 func ValidateTier(tier int, files []FileChange) error {
 	if tier < 2 {
 		return fmt.Errorf("tier %d agents cannot create PRs; minimum tier is 2", tier)

--- a/internal/web/api_handlers.go
+++ b/internal/web/api_handlers.go
@@ -482,11 +482,13 @@ func (s *Server) handleAPICreatePR(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Governing: SPEC-0018 REQ-9 "Permission Tier Integration" — tier gate enforced at API level.
 	if err := gitprovider.ValidateTier(req.Tier, req.Files); err != nil {
 		writeError(w, http.StatusForbidden, err.Error())
 		return
 	}
 
+	// Governing: SPEC-0018 REQ-12 "Dry Run Mode" — log proposed PR details without executing git operations.
 	if s.cfg.DryRun {
 		log.Printf("[PR] Dry run: would create PR '%s' for %s/%s", req.Title, req.RepoOwner, req.RepoName)
 		writeJSON(w, http.StatusOK, APICreatePRResponse{DryRun: true})

--- a/internal/web/api_types.go
+++ b/internal/web/api_types.go
@@ -99,11 +99,13 @@ type APIConfig struct {
 // --- PR API Types ---
 
 // APICreatePRRequest is the JSON body for POST /api/v1/prs.
+// Governing: SPEC-0018 REQ-9 "Permission Tier Integration" (Tier field), REQ-12 "Dry Run Mode".
 type APICreatePRRequest struct {
 	RepoOwner  string                   `json:"repo_owner"`
 	RepoName   string                   `json:"repo_name"`
 	CloneURL   string                   `json:"clone_url"`
-	Tier       int                      `json:"tier"`
+	Tier       int                      `json:"tier"` // Governing: SPEC-0018 REQ-9 — tier carried in request for enforcement.
+
 	Files      []gitprovider.FileChange `json:"files"`
 	Title      string                   `json:"title"`
 	Body       string                   `json:"body"`
@@ -112,6 +114,7 @@ type APICreatePRRequest struct {
 }
 
 // APICreatePRResponse is returned after creating a pull request.
+// Governing: SPEC-0018 REQ-12 "Dry Run Mode" — DryRun field signals no git operations were executed.
 type APICreatePRResponse struct {
 	Number int    `json:"number"`
 	URL    string `json:"url"`

--- a/prompts/tier1-observe.md
+++ b/prompts/tier1-observe.md
@@ -39,6 +39,7 @@ Your tier is: **Tier 1**
 
 Governing: SPEC-0023 REQ-6, ADR-0023
 
+<!-- Governing: SPEC-0018 REQ-12 "Dry Run Mode" — PR creation included in mutating operations denied during dry run -->
 ## Dry-Run Mode
 
 When `CLAUDEOPS_DRY_RUN=true`:

--- a/prompts/tier2-investigate.md
+++ b/prompts/tier2-investigate.md
@@ -48,6 +48,7 @@ Your tier is: **Tier 2**
 
 Governing: SPEC-0023 REQ-6, ADR-0023
 
+<!-- Governing: SPEC-0018 REQ-12 "Dry Run Mode" — PR creation included in mutating operations denied during dry run -->
 ## Dry-Run Mode
 
 When `CLAUDEOPS_DRY_RUN=true`:
@@ -202,6 +203,7 @@ After each remediation:
 - Update the cooldown state file
 - Verify the fix by re-checking the service
 
+<!-- Governing: SPEC-0018 REQ-9 "Permission Tier Integration" — Tier 2 permitted to create PRs for non-structural changes -->
 ## Limited Access Fallback
 
 When a remediation requires elevated privileges (write commands like `docker restart`, `systemctl`, `chown`, file edits) on a host where the access map shows `method: "limited"`:

--- a/prompts/tier3-remediate.md
+++ b/prompts/tier3-remediate.md
@@ -105,6 +105,7 @@ Your tier is: **Tier 3**
 
 Governing: SPEC-0023 REQ-6, ADR-0023
 
+<!-- Governing: SPEC-0018 REQ-12 "Dry Run Mode" — PR creation included in mutating operations denied during dry run -->
 ## Dry-Run Mode
 
 When `CLAUDEOPS_DRY_RUN=true`:
@@ -216,6 +217,7 @@ Use the correct SSH user and sudo prefix from the host access map (see `/app/ski
 5. Verify connectivity from dependent services
 6. Check for data integrity issues (but NEVER delete data)
 
+<!-- Governing: SPEC-0018 REQ-9 "Permission Tier Integration" — Tier 3 permitted to create PRs for structural changes -->
 ## Limited Access Fallback
 
 When a remediation requires elevated privileges (write commands like `docker restart`, `docker compose`, `systemctl`, `chown`, Ansible playbooks, Helm upgrades) on a host where the access map shows `method: "limited"`:


### PR DESCRIPTION
## Summary

- Add `Governing: SPEC-0018 REQ-9 "Permission Tier Integration"` comments to `ValidateTier()` in `tier.go`, the API handler tier gate in `api_handlers.go`, the `APICreatePRRequest.Tier` field in `api_types.go`, and the Limited Access Fallback sections in `tier2-investigate.md` and `tier3-remediate.md`
- Add `Governing: SPEC-0018 REQ-12 "Dry Run Mode"` comments to the dry-run gate in `api_handlers.go`, the `APICreatePRResponse.DryRun` field in `api_types.go`, and the Dry-Run Mode sections in all three tier prompts

## Files Changed

| File | Governing |
|------|-----------|
| `internal/gitprovider/tier.go` | REQ-9 on `ValidateTier()` |
| `internal/web/api_handlers.go` | REQ-9 on tier gate, REQ-12 on dry-run gate |
| `internal/web/api_types.go` | REQ-9 on `Tier` field, REQ-12 on `DryRun` response field |
| `prompts/tier1-observe.md` | REQ-12 on Dry-Run Mode section |
| `prompts/tier2-investigate.md` | REQ-9 on Limited Access Fallback, REQ-12 on Dry-Run Mode |
| `prompts/tier3-remediate.md` | REQ-9 on Limited Access Fallback, REQ-12 on Dry-Run Mode |

## Test plan

- [x] `go vet ./...` passes
- [x] `go test ./... -count=1 -race` passes (all packages)

Closes #364
Part of epic #219
Part of SPEC-0018

🤖 Generated with [Claude Code](https://claude.com/claude-code)