### PR TITLE
Add governing comments for SPEC-0020 host access map and caching

### DIFF
--- a/skills/ssh-discovery.md
+++ b/skills/ssh-discovery.md
@@ -6,6 +6,8 @@ Discover the SSH access method for each managed host at the start of every monit
 
 Run once per cycle, after repo and service discovery (Step 2) and before health checks (Step 3). Extract the host list from the CLAUDE-OPS.md manifest's Hosts table.
 
+<!-- Governing: SPEC-0020 "Manifest as Advisory" — CLAUDE-OPS.md SSH config is advisory, verified at runtime -->
+
 ## Probing Order
 
 For each host, attempt SSH connections in this order. Stop on the first success.
@@ -55,6 +57,8 @@ ssh <user>@<host> docker info --format '{{.ServerVersion}}'
 - If the command succeeds, record `can_docker: true`
 - If it fails (permission error), record `can_docker: false`
 
+<!-- Governing: SPEC-0020 "Host Access Map Structure" — per-host JSON with user, method, can_docker -->
+
 ## Host Access Map Schema
 
 Build a JSON map with one entry per host:
@@ -85,6 +89,8 @@ Build a JSON map with one entry per host:
   }
 }
 ```
+
+<!-- Governing: SPEC-0020 "Per-Run Caching" — computed once per cycle, passed via handoff to higher tiers -->
 
 ## Caching
 


### PR DESCRIPTION
## Summary
- Adds governing comments tracing SPEC-0020 Host Access Map Structure, Per-Run Caching, and Manifest as Advisory to their implementation
- Annotated file: `skills/ssh-discovery.md`

Closes #371 / Part of epic #94 / Part of SPEC-0020

## Test plan
- [x] `go vet ./...` passes
- [x] `go test ./... -count=1 -race` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)