### PR TITLE
Add governing comments for command execution & gating (SPEC-0020)

### DIFF
--- a/prompts/tier1-observe.md
+++ b/prompts/tier1-observe.md
@@ -231,6 +231,7 @@ Run checks ONLY against the hosts and services discovered from repos. **Never ch
 - For services with DNS names: `dig +short <hostname>`
 - Verify it resolves to the expected IP/CNAME
 
+<!-- Governing: SPEC-0020 "Command Prefix Based on Access Method" — use host access map for SSH prefix -->
 ### Container State (Remote Only via SSH)
 - **Only if** the repo provides SSH access to the target host
 - **Use the host access map** (built in Step 2.5) to determine the SSH user and method for each host. See `/app/skills/ssh-discovery.md` for command construction rules.

--- a/prompts/tier2-investigate.md
+++ b/prompts/tier2-investigate.md
@@ -167,6 +167,8 @@ Read the failure summary provided by Tier 1. For each failed service, note:
 <!-- Governing: SPEC-0020 "Tier Integration" — Tier 2 reuses the SSH access map from handoff -->
 Read the **SSH host access map** from the handoff file. The map tells you which user and method (`root`, `sudo`, `limited`, `unreachable`) to use for each host. If the handoff includes an `ssh_access_map` field, use it directly — do NOT re-probe SSH access. If the map is missing, read `/app/skills/ssh-discovery.md` and run the discovery routine before proceeding.
 
+<!-- Governing: SPEC-0020 "Command Prefix Based on Access Method" — SSH prefix per host access map -->
+<!-- Governing: SPEC-0020 "Write Command Gating" — limited-access hosts restricted to read commands -->
 ## Remote Host Access
 
 **Always use SSH** for all remote host operations. Consult the host access map (from the handoff file) and `/app/skills/ssh-discovery.md` to construct the correct SSH command for each host:
@@ -209,6 +211,7 @@ Read the applicable playbook files from `/app/playbooks/` and `.claude-ops/playb
 
 Apply the appropriate remediation from `/app/playbooks/`. Common patterns:
 
+<!-- Governing: SPEC-0020 "Command Prefix Based on Access Method", "Write Command Gating" -->
 ### Container restart
 1. Look up the host in the access map. Use the correct SSH user and sudo prefix per `/app/skills/ssh-discovery.md` (e.g., `ssh <user>@<host> sudo docker restart <container>` for sudo hosts, `ssh root@<host> docker restart <container>` for root hosts). If the host has `method: limited`, this remediation CANNOT be executed — follow the Limited Access Fallback below.
 2. Wait 15-30 seconds

--- a/prompts/tier3-remediate.md
+++ b/prompts/tier3-remediate.md
@@ -198,6 +198,8 @@ With the full picture, determine the actual root cause:
 
 Read `/app/skills/cooldowns.md` for cooldown rules, then read `/state/cooldown.json`. If cooldown limit is exceeded, skip to Step 5 (report as needs human attention).
 
+<!-- Governing: SPEC-0020 "Command Prefix Based on Access Method" — SSH prefix per host access map -->
+<!-- Governing: SPEC-0020 "Write Command Gating" — limited-access hosts restricted to read commands -->
 ## Remote Host Access
 
 **Always use SSH** for all remote host operations. Consult the host access map (from the handoff file) and `/app/skills/ssh-discovery.md` to construct the correct SSH command for each host:
@@ -229,6 +231,7 @@ Read the applicable playbook files from `/app/playbooks/` and `.claude-ops/playb
 4. Verify pods are healthy
 5. Update cooldown state
 
+<!-- Governing: SPEC-0020 "Command Prefix Based on Access Method", "Write Command Gating" -->
 ### Container recreation
 Use the correct SSH user and sudo prefix from the host access map (see `/app/skills/ssh-discovery.md`). If the host has `method: limited`, follow the Limited Access Fallback below instead.
 1. `ssh <user>@<host> [sudo] "cd <compose-dir> && docker compose down <service>"`

--- a/skills/ssh-discovery.md
+++ b/skills/ssh-discovery.md
@@ -111,6 +111,8 @@ Log the discovery result for each host:
 - **Unreachable**: `SSH discovery: <host> -> unreachable (tried: root, <manifest_user>, ubuntu, debian, pi, admin)`
 
 <!-- Governing: SPEC-0020 "Tier Integration" — all tiers consult the access map for SSH command construction -->
+<!-- Governing: SPEC-0020 "Command Prefix Based on Access Method" — select SSH prefix based on host access map entry -->
+
 
 ## Command Execution Rules
 
@@ -140,6 +142,7 @@ ssh <user>@<host> sudo docker ps
 ssh <user>@<host> <command>
 ```
 
+<!-- Governing: SPEC-0020 "Write Command Gating" — block write commands on limited-access hosts -->
 ### method: limited
 ```bash
 ssh <user>@<host> <command>


### PR DESCRIPTION
## Summary

- Add `Governing: SPEC-0020 "Command Prefix Based on Access Method"` comments to the Remote Host Access sections in all three tier prompts, the Container State section in tier1-observe.md, the Container restart/recreation steps in tier2 and tier3, and the Command Execution Rules section in ssh-discovery.md
- Add `Governing: SPEC-0020 "Write Command Gating"` comments to the `method: limited` rules in tier2/tier3 Remote Host Access sections, the container restart/recreation steps, and the limited method section in ssh-discovery.md

## Files Changed

| File | Governing |
|------|-----------|
| `skills/ssh-discovery.md` | "Command Prefix Based on Access Method" on Command Execution Rules, "Write Command Gating" on method: limited |
| `prompts/tier1-observe.md` | "Command Prefix Based on Access Method" on Container State (Remote Only via SSH) |
| `prompts/tier2-investigate.md` | Both requirements on Remote Host Access and Container restart step |
| `prompts/tier3-remediate.md` | Both requirements on Remote Host Access and Container recreation step |

## Test plan

- [x] `go vet ./...` passes
- [x] `go test ./... -count=1 -race` passes (all packages)

Closes #372
Part of epic #94
Part of SPEC-0020

🤖 Generated with [Claude Code](https://claude.com/claude-code)