### PR TITLE
Add governing comments for access detection (SPEC-0020)

### DIFF
--- a/prompts/tier1-observe.md
+++ b/prompts/tier1-observe.md
@@ -144,7 +144,7 @@ Before running health checks, discover the SSH access method for each managed ho
 1. Read `/app/skills/ssh-discovery.md` for the full procedure
 2. Extract the host list from the CLAUDE-OPS.md manifest's Hosts table
 3. For each host, probe SSH access in order: root, manifest-declared user, common defaults (ubuntu, debian, pi, admin)
-4. For non-root users, detect sudo access and Docker access
+4. For non-root users, detect sudo access and Docker access <!-- Governing: SPEC-0020 REQ "Sudo Access Detection", REQ "Docker Access Detection" -->
 5. Build the host access map (JSON with user, method, can_docker per host)
 6. Log the discovery results for each host
 

--- a/skills/ssh-discovery.md
+++ b/skills/ssh-discovery.md
@@ -26,6 +26,7 @@ ssh -o BatchMode=yes -o ConnectTimeout=5 <user>@<host> whoami
 
 If all probes fail for a host, record it as `unreachable` and move on. Do not block the rest of the cycle.
 
+<!-- Governing: SPEC-0020 REQ "Sudo Access Detection" — test passwordless sudo via 'sudo -n whoami', record method as "sudo" or "limited" -->
 ## Sudo Detection
 
 For any non-root user that successfully connects, test for passwordless sudo:
@@ -37,6 +38,7 @@ ssh <user>@<host> 'sudo -n whoami 2>/dev/null'
 - If the output is `root`, record `method: "sudo"`
 - Otherwise, record `method: "limited"`
 
+<!-- Governing: SPEC-0020 REQ "Docker Access Detection" — test docker info with appropriate sudo prefix, record can_docker flag -->
 ## Docker Access Detection
 
 For every successfully connected host, test Docker access:


### PR DESCRIPTION
## Summary
- Added governing comments tracing sudo access detection and Docker access detection to SPEC-0020 requirements
- `skills/ssh-discovery.md`: Annotated Sudo Detection and Docker Access Detection sections
- `prompts/tier1-observe.md`: Annotated step 2.5 where detection is invoked

Closes #370
Part of SPEC-0020

## Test plan
- [x] `go vet ./...` passes
- [x] `go test ./... -count=1 -race` passes
- [x] Comments only — no logic changes