### PR TITLE
Add OpenAI chat request parsing, session triggering & stateless session semantics (#472)

### DIFF
--- a/internal/web/server_test.go
+++ b/internal/web/server_test.go
@@ -18,12 +18,14 @@ import (
 )
 
 type mockTrigger struct {
-	running bool
-	nextID  int64
-	nextErr error
+	running    bool
+	nextID     int64
+	nextErr    error
+	lastPrompt string // captures the prompt passed to TriggerAdHoc
 }
 
 func (m *mockTrigger) TriggerAdHoc(prompt string) (int64, error) {
+	m.lastPrompt = prompt
 	if m.nextErr != nil {
 		return 0, m.nextErr
 	}


### PR DESCRIPTION
Closes #472
Part of #470 (SPEC-0024 epic)
Governing: ADR-0020, ADR-0013, SPEC-0024 REQ-3/REQ-4/REQ-9

## Summary
- Add REQ-9 (Stateless Sessions) governing comments to chat handler
- Enhance `mockTrigger` to capture `lastPrompt` for prompt extraction verification
- Add 8 new tests covering all REQ-3/REQ-4/REQ-9 scenarios:
  - Last user message extracted as prompt (multi-message array)
  - Single user message from `stream:true` request
  - Model field ignored (`gpt-4` accepted, response always `claude-ops`)
  - Prior assistant/system messages not injected as context
  - Whitespace-only user messages rejected (400)
  - 429 error body matches spec exactly
  - Usage tokens zeroed in synchronous response
  - Stream field defaults to false when omitted

## Test plan
- [x] `go vet ./...` passes
- [x] `go test ./... -count=1 -race` passes (all existing + 8 new tests)
- [ ] CI green on GitHub Actions

> **Note:** This PR targets the `feature/471-openai-chat-foundation-routes-auth-models` branch since #472 depends on #471. Merge #471 first.