### PR TITLE
Implement OpenAI SSE streaming, sync response & error format (#473)

### DIFF
--- a/cmd/claudeops/main.go
+++ b/cmd/claudeops/main.go
@@ -154,7 +154,8 @@ func run(cmd *cobra.Command, args []string) error {
 	// Governing: SPEC-0008 REQ-2 (Web Server — HTTP on configurable port, default 8080)
 	// Create and start web server (needs mgr for ad-hoc session triggers).
 	// Governing: SPEC-0023 REQ-9 — git provider registry removed; PR operations are now skill-based.
-	webServer := web.New(&cfg, sseHub, database, mgr)
+	// Governing: SPEC-0024 REQ-5 — pass raw hub for OpenAI streaming
+	webServer := web.New(&cfg, sseHub, database, mgr, web.WithRawHub(mgr.RawHub()))
 	go func() {
 		if err := webServer.Start(); err != nil {
 			log.Printf("web server error: %v", err)

--- a/internal/web/chat_handler.go
+++ b/internal/web/chat_handler.go
@@ -7,12 +7,15 @@ import (
 	"net/http"
 	"os"
 	"strings"
+
+	"github.com/google/uuid"
 )
 
 // Governing: SPEC-0024 REQ-1 (Endpoint Registration), REQ-2 (Authentication), ADR-0020
 
 // handleChatCompletions handles POST /v1/chat/completions.
-// Governing: SPEC-0024 REQ-2 (Authentication), REQ-3 (Request Parsing), REQ-4 (Session Triggering), REQ-9 (Stateless Sessions), ADR-0020
+// Governing: SPEC-0024 REQ-2 (Authentication), REQ-3 (Request Parsing), REQ-4 (Session Triggering),
+// REQ-5 (Streaming Response), REQ-6 (Synchronous Response), REQ-9 (Stateless Sessions), ADR-0020
 func (s *Server) handleChatCompletions(w http.ResponseWriter, r *http.Request) {
 	// Governing: SPEC-0024 REQ-2 — read key from env on each request (supports rotation without restart)
 	apiKey := os.Getenv("CLAUDEOPS_CHAT_API_KEY")
@@ -59,29 +62,286 @@ func (s *Server) handleChatCompletions(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Return a minimal synchronous response indicating the session was triggered.
-	// Full streaming (REQ-5) and synchronous wait (REQ-6) are implemented in #473.
-	// Governing: SPEC-0024 REQ-6 (Synchronous Response) — non-streaming placeholder
-	w.Header().Set("Content-Type", "application/json")
-	resp := ChatCompletion{
-		ID:     fmt.Sprintf("chatcmpl-%d", sessionID),
-		Object: "chat.completion",
+	// Generate a request ID for the response.
+	// Governing: SPEC-0024 REQ-10 — id starts with recognizable prefix
+	requestID := fmt.Sprintf("chatcmpl-%s", uuid.New().String())
+
+	if req.Stream {
+		s.handleChatStream(w, r, sessionID, requestID)
+	} else {
+		s.handleChatSync(w, r, sessionID, requestID)
+	}
+}
+
+// handleChatStream implements SSE streaming for stream:true requests.
+// Governing: SPEC-0024 REQ-5 (Streaming Response), ADR-0020
+func (s *Server) handleChatStream(w http.ResponseWriter, r *http.Request, sessionID int64, requestID string) {
+	flusher, ok := w.(http.Flusher)
+	if !ok {
+		writeChatError(w, http.StatusInternalServerError, "Streaming not supported", "server_error", "internal_error")
+		return
+	}
+
+	if s.rawHub == nil {
+		writeChatError(w, http.StatusInternalServerError, "Streaming not available", "server_error", "internal_error")
+		return
+	}
+
+	w.Header().Set("Content-Type", "text/event-stream")
+	w.Header().Set("Cache-Control", "no-cache")
+	w.Header().Set("Connection", "keep-alive")
+	w.Header().Set("X-Accel-Buffering", "no")
+
+	ch, unsubscribe := s.rawHub.Subscribe(int(sessionID))
+	defer unsubscribe()
+
+	// Governing: SPEC-0024 REQ-5 — send role indicator in first chunk
+	sendSSEChunk(w, flusher, requestID, ChatCompletionChunk{
+		ID:     requestID,
+		Object: "chat.completion.chunk",
 		Model:  "claude-ops",
-		Choices: []CompletionChoice{
-			{
+		Choices: []Choice{{
+			Index: 0,
+			Delta: Delta{Role: "assistant"},
+		}},
+	})
+
+	ctx := r.Context()
+	var toolCallIndex int
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case raw, ok := <-ch:
+			if !ok {
+				// Session ended — send finish chunk and [DONE]
+				sendSSEChunk(w, flusher, requestID, ChatCompletionChunk{
+					ID:     requestID,
+					Object: "chat.completion.chunk",
+					Model:  "claude-ops",
+					Choices: []Choice{{
+						Index:        0,
+						Delta:        Delta{},
+						FinishReason: "stop",
+					}},
+				})
+				_, _ = fmt.Fprintf(w, "data: [DONE]\n\n")
+				flusher.Flush()
+				return
+			}
+
+			chunks := s.rawEventToChunks(raw, requestID, &toolCallIndex)
+			for _, chunk := range chunks {
+				sendSSEChunk(w, flusher, requestID, chunk)
+			}
+		}
+	}
+}
+
+// handleChatSync implements the synchronous response for stream:false requests.
+// Governing: SPEC-0024 REQ-6 (Synchronous Response), ADR-0020
+func (s *Server) handleChatSync(w http.ResponseWriter, r *http.Request, sessionID int64, requestID string) {
+	if s.rawHub == nil {
+		// Fallback: return a minimal response with session ID
+		w.Header().Set("Content-Type", "application/json")
+		resp := ChatCompletion{
+			ID:     requestID,
+			Object: "chat.completion",
+			Model:  "claude-ops",
+			Choices: []CompletionChoice{{
 				Index: 0,
 				Message: ChatMessage{
 					Role:    "assistant",
-					Content: fmt.Sprintf("Session %d triggered. Streaming response will be available in a future release.", sessionID),
+					Content: fmt.Sprintf("Session %d triggered.", sessionID),
 				},
 				FinishReason: "stop",
+			}},
+			Usage: ChatUsage{},
+		}
+		_ = json.NewEncoder(w).Encode(resp)
+		return
+	}
+
+	ch, unsubscribe := s.rawHub.Subscribe(int(sessionID))
+	defer unsubscribe()
+
+	// Collect all assistant text content until the session ends.
+	var contentParts []string
+	ctx := r.Context()
+loop:
+	for {
+		select {
+		case <-ctx.Done():
+			writeChatError(w, http.StatusInternalServerError, "Request cancelled", "server_error", "request_cancelled")
+			return
+		case raw, ok := <-ch:
+			if !ok {
+				break loop
+			}
+			text := extractAssistantText(raw)
+			if text != "" {
+				contentParts = append(contentParts, text)
+			}
+		}
+	}
+
+	fullContent := strings.Join(contentParts, "")
+
+	// Governing: SPEC-0024 REQ-6 — synchronous response with zeroed usage
+	w.Header().Set("Content-Type", "application/json")
+	resp := ChatCompletion{
+		ID:     requestID,
+		Object: "chat.completion",
+		Model:  "claude-ops",
+		Choices: []CompletionChoice{{
+			Index: 0,
+			Message: ChatMessage{
+				Role:    "assistant",
+				Content: fullContent,
 			},
-		},
+			FinishReason: "stop",
+		}},
 		Usage: ChatUsage{},
 	}
 	if err := json.NewEncoder(w).Encode(resp); err != nil {
 		writeChatError(w, http.StatusInternalServerError, "Failed to encode response", "server_error", "internal_error")
 	}
+}
+
+// rawEventToChunks converts a raw NDJSON stream-json event into zero or more OpenAI SSE chunks.
+// Governing: SPEC-0024 REQ-5 — event type mapping to OpenAI chunk format
+func (s *Server) rawEventToChunks(raw string, requestID string, toolCallIndex *int) []ChatCompletionChunk {
+	var evt struct {
+		Type    string `json:"type"`
+		Subtype string `json:"subtype,omitempty"`
+		Message struct {
+			Content []struct {
+				Type  string          `json:"type"`
+				Text  string          `json:"text,omitempty"`
+				Name  string          `json:"name,omitempty"`
+				Input json.RawMessage `json:"input,omitempty"`
+			} `json:"content"`
+		} `json:"message,omitempty"`
+		Result  string `json:"result,omitempty"`
+		IsError bool   `json:"is_error,omitempty"`
+	}
+	if err := json.Unmarshal([]byte(raw), &evt); err != nil {
+		return nil
+	}
+
+	var chunks []ChatCompletionChunk
+
+	switch evt.Type {
+	case "assistant":
+		for _, block := range evt.Message.Content {
+			switch block.Type {
+			case "text":
+				text := block.Text
+				if text == "" {
+					continue
+				}
+				chunks = append(chunks, ChatCompletionChunk{
+					ID:     requestID,
+					Object: "chat.completion.chunk",
+					Model:  "claude-ops",
+					Choices: []Choice{{
+						Index: 0,
+						Delta: Delta{Content: text},
+					}},
+				})
+			case "tool_use":
+				args := "{}"
+				if len(block.Input) > 0 {
+					args = string(block.Input)
+				}
+				idx := *toolCallIndex
+				*toolCallIndex++
+				chunks = append(chunks, ChatCompletionChunk{
+					ID:     requestID,
+					Object: "chat.completion.chunk",
+					Model:  "claude-ops",
+					Choices: []Choice{{
+						Index: 0,
+						Delta: Delta{
+							ToolCalls: []ToolCall{{
+								Index: idx,
+								Type:  "function",
+								Function: ToolFunction{
+									Name:      block.Name,
+									Arguments: args,
+								},
+							}},
+						},
+					}},
+				})
+			}
+		}
+
+	case "result":
+		// Session end — send finish chunk with error text if applicable
+		chunk := ChatCompletionChunk{
+			ID:     requestID,
+			Object: "chat.completion.chunk",
+			Model:  "claude-ops",
+			Choices: []Choice{{
+				Index:        0,
+				FinishReason: "stop",
+			}},
+		}
+		if evt.IsError && evt.Result != "" {
+			chunk.Choices[0].Delta = Delta{Content: evt.Result}
+		} else {
+			chunk.Choices[0].Delta = Delta{}
+		}
+		chunks = append(chunks, chunk)
+	}
+
+	return chunks
+}
+
+// extractAssistantText pulls text content from an assistant stream-json event.
+func extractAssistantText(raw string) string {
+	var evt struct {
+		Type    string `json:"type"`
+		Message struct {
+			Content []struct {
+				Type string `json:"type"`
+				Text string `json:"text,omitempty"`
+			} `json:"content"`
+		} `json:"message,omitempty"`
+		Result  string `json:"result,omitempty"`
+		IsError bool   `json:"is_error,omitempty"`
+	}
+	if err := json.Unmarshal([]byte(raw), &evt); err != nil {
+		return ""
+	}
+
+	switch evt.Type {
+	case "assistant":
+		var parts []string
+		for _, block := range evt.Message.Content {
+			if block.Type == "text" && block.Text != "" {
+				parts = append(parts, block.Text)
+			}
+		}
+		return strings.Join(parts, "")
+	case "result":
+		if evt.IsError && evt.Result != "" {
+			return evt.Result
+		}
+		return evt.Result
+	}
+	return ""
+}
+
+// sendSSEChunk marshals a chunk and writes it as an SSE data event.
+func sendSSEChunk(w http.ResponseWriter, flusher http.Flusher, _ string, chunk ChatCompletionChunk) {
+	data, err := json.Marshal(chunk)
+	if err != nil {
+		return
+	}
+	_, _ = fmt.Fprintf(w, "data: %s\n\n", data)
+	flusher.Flush()
 }
 
 // handleModels handles GET /v1/models.


### PR DESCRIPTION
Closes #473
Part of #470 (SPEC-0024 epic)
Governing: ADR-0020, ADR-0011, SPEC-0024 REQ-5/REQ-6/REQ-7/REQ-10

Depends on #483 (rebased from original #479)

## Summary

- **REQ-5 Streaming**: Subscribes to a new raw NDJSON hub that publishes CLI stream-json events. Transforms `assistant` text blocks into `delta.content` chunks, `tool_use` blocks into `delta.tool_calls` with JSON-encoded arguments, and `result` events into `finish_reason: "stop"` terminators. Final `data: [DONE]` event signals end-of-stream.
- **REQ-6 Synchronous**: Collects all assistant text output from the session and returns a single `chat.completion` object with zeroed usage tokens.
- **REQ-7 Error Format**: All error paths (400/401/429/503/500) consistently use `{"error":{"message","type","code"}}`.
- **REQ-10 SDK Compatibility**: `chatcmpl-<uuid>` ID prefix, correct `object` field values (`chat.completion` vs `chat.completion.chunk`), standard SSE format.

## Architecture

Adds a `rawHub` to the session manager that publishes raw NDJSON lines alongside the existing HTML-formatted hub. The OpenAI chat handler subscribes to the raw hub; the dashboard continues using the formatted hub. The raw hub is passed to the web server via the `WithRawHub` functional option.

## Context
Rebased onto the rebased #483 branch after PR #477 was squash-merged to main. Original PR chain was #477 -> #479 -> #481. Now it is: main -> #483 -> #481. Code is unchanged from the reviewed and approved original.

## Test plan

- [x] SSE streaming format: role indicator chunk, content deltas, tool call deltas, finish chunk, [DONE]
- [x] Sync response: collected text in message.content, zeroed usage
- [x] Error format: 400/401/429/503 all return OpenAI error JSON
- [x] SDK compatibility: chatcmpl- ID prefix, correct object types
- [x] All existing tests pass (models endpoint, auth, request parsing, stateless sessions)
- [x] `go vet ./...` clean
- [x] `go test ./... -count=1 -race` passes