### PR TITLE
Rename /design: namespace to /sdd:

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -172,23 +172,23 @@ The typical flow is:
 
 ## Architecture Context
 
-This project uses the [design plugin](https://github.com/joestump/claude-plugin-design) for architecture governance.
+This project uses the [SDD plugin](https://github.com/joestump/claude-plugin-sdd) for architecture governance.
 
 - Architecture Decision Records are in `docs/adrs/`
 - Specifications are in `docs/openspec/specs/`
 
-### Design Plugin Skills
+### SDD Skills
 
 | Skill | Purpose |
 |-------|---------|
-| `/design:adr` | Create a new Architecture Decision Record |
-| `/design:spec` | Create a new specification |
-| `/design:list` | List all ADRs and specs with status |
-| `/design:status` | Update the status of an ADR or spec |
-| `/design:docs` | Generate a documentation site |
-| `/design:init` | Set up CLAUDE.md with architecture context |
-| `/design:prime` | Load architecture context into session |
-| `/design:check` | Quick-check code against ADRs and specs for drift |
-| `/design:audit` | Comprehensive design artifact alignment audit |
+| `/sdd:adr` | Create a new Architecture Decision Record |
+| `/sdd:spec` | Create a new specification |
+| `/sdd:list` | List all ADRs and specs with status |
+| `/sdd:status` | Update the status of an ADR or spec |
+| `/sdd:docs` | Generate a documentation site |
+| `/sdd:init` | Set up CLAUDE.md with architecture context |
+| `/sdd:prime` | Load architecture context into session |
+| `/sdd:check` | Quick-check code against ADRs and specs for drift |
+| `/sdd:audit` | Comprehensive design artifact alignment audit |
 
-Run `/design:prime [topic]` at the start of a session to load relevant ADRs and specs into context.
+Run `/sdd:prime [topic]` at the start of a session to load relevant ADRs and specs into context.

--- a/audit-report.md
+++ b/audit-report.md
@@ -50,7 +50,7 @@ No findings. Reviewed all ADR-spec pairings (ADR-0011/SPEC-0011 through ADR-0019
 
 | Severity | Finding | Source | Location |
 |----------|---------|--------|----------|
-| [INFO] | CLAUDE.md states spec numbering is `RFC-XXXX` but all actual specs use `SPEC-XXXX`. The CLAUDE.md instruction contradicts the design plugin's spec template and every existing spec file. Future spec creation guided by CLAUDE.md would use the wrong prefix. | CLAUDE.md | CLAUDE.md:265 |
+| [INFO] | CLAUDE.md states spec numbering is `RFC-XXXX` but all actual specs use `SPEC-XXXX`. The CLAUDE.md instruction contradicts the SDD plugin's spec template and every existing spec file. Future spec creation guided by CLAUDE.md would use the wrong prefix. | CLAUDE.md | CLAUDE.md:265 |
 
 ---
 
@@ -70,6 +70,6 @@ No findings. Reviewed all ADR-spec pairings (ADR-0011/SPEC-0011 through ADR-0019
 
 1. [CRITICAL] Add `schema_version` field to the `Handoff` struct in `internal/session/handoff.go` and add validation in `ValidateHandoff()` to reject unrecognized versions, per SPEC-0016-REQ-1.
 2. [WARNING] Decide whether `CLAUDEOPS_PR_ENABLED` gate is intentional. If so, update SPEC-0019-REQ-2 to document the env var gate on `create_pr` and change the "exactly three tools" requirement. If not, remove the gate and always expose `create_pr` with server-side tier enforcement as the spec requires.
-3. [WARNING] Update status of ADR-0011, ADR-0012, ADR-0013, ADR-0014, ADR-0015, ADR-0016, ADR-0017, ADR-0018, ADR-0019 from `proposed` to `accepted`. Use `/design:status` to update each.
+3. [WARNING] Update status of ADR-0011, ADR-0012, ADR-0013, ADR-0014, ADR-0015, ADR-0016, ADR-0017, ADR-0018, ADR-0019 from `proposed` to `accepted`. Use `/sdd:status` to update each.
 4. [INFO] Fix CLAUDE.md line 265: change `RFC-XXXX` to `SPEC-XXXX` to match actual spec numbering convention.
-5. [INFO] Consider creating a spec for the CLI interface (`cmd/claudeops/` subcommands and flags). Use `/design:spec cli-interface`.
+5. [INFO] Consider creating a spec for the CLI interface (`cmd/claudeops/` subcommands and flags). Use `/sdd:spec cli-interface`.


### PR DESCRIPTION
## Summary

Mechanical sweep updating references from the old `/design:` plugin namespace to `/sdd:` (Spec-Driven Development). The plugin was renamed in joestump/claude-plugin-sdd#75 because Anthropic shipped an official `design` plugin that collides with the namespace.

Changes are limited to documentation strings:
- `/design:*` → `/sdd:*`
- `claude-plugin-design` → `claude-plugin-sdd`
- "design plugin" / "Design Plugin" → "SDD plugin" / "SDD Plugin"
- `### Design Plugin Configuration` heading → `### SDD Configuration`

No behavior changes.

## Test plan

- [x] `git diff` reviewed — only namespace/branding strings changed
- [ ] After merge, run `/sdd:prime` to confirm the new namespace resolves

🤖 Generated with [Claude Code](https://claude.com/claude-code)