### PR TITLE
feat(api): add GET /api/v1/stats endpoint for external dashboards (Homepage HUD)

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -44,6 +44,48 @@ paths:
               example:
                 status: ok
 
+  /api/v1/stats:
+    get:
+      summary: Dashboard stats (TL;DR HUD)
+      description: >
+        Returns the aggregate metrics shown in the dashboard's TL;DR HUD —
+        total runs, escalations, remediations, success rate, total cost, active
+        memories, critical events (last 24h), and average duration — plus the
+        most recent session and the next scheduled run time. Intended for
+        external dashboards (e.g. Homepage) to poll. Unauthenticated.
+      operationId: getStats
+      responses:
+        "200":
+          description: Dashboard stats snapshot
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/StatsResponse"
+              example:
+                stats:
+                  total_runs: 142
+                  escalations: 9
+                  remediations: 3
+                  success_rate: 0.95
+                  total_cost_usd: 12.4831
+                  active_memories: 27
+                  critical_events: 1
+                  avg_duration_ms: 84210
+                last_session:
+                  id: 142
+                  tier: 1
+                  status: completed
+                  started_at: "2026-06-21T10:00:00Z"
+                  ended_at: "2026-06-21T10:01:24Z"
+                  cost_usd: 0.0731
+                  duration_ms: 84210
+                  trigger: scheduled
+                  summary: All 5 services healthy; no action taken.
+                next_run: "2026-06-21T11:00:00Z"
+                interval_seconds: 3600
+        "500":
+          $ref: "#/components/responses/InternalError"
+
   /api/v1/sessions:
     get:
       summary: List sessions
@@ -1164,6 +1206,108 @@ components:
         dry_run:
           type: boolean
           description: Whether the agent is in observe-only mode.
+
+    Stats:
+      type: object
+      required:
+        - total_runs
+        - escalations
+        - remediations
+        - success_rate
+        - total_cost_usd
+        - active_memories
+        - critical_events
+        - avg_duration_ms
+      properties:
+        total_runs:
+          type: integer
+          description: Total root sessions (parent_session_id IS NULL).
+        escalations:
+          type: integer
+          description: Child sessions spawned by escalation (parent_session_id IS NOT NULL).
+        remediations:
+          type: integer
+          description: Tier 3 (remediate) sessions.
+        success_rate:
+          type: number
+          format: float
+          description: Completed root sessions / total root sessions (0–1).
+        total_cost_usd:
+          type: number
+          format: double
+          description: Sum of cost_usd across all sessions.
+        active_memories:
+          type: integer
+          description: Count of active memories.
+        critical_events:
+          type: integer
+          description: Critical-level events in the last 24 hours.
+        avg_duration_ms:
+          type: integer
+          format: int64
+          description: Average session duration in milliseconds.
+
+    StatsSession:
+      type: object
+      required:
+        - id
+        - tier
+        - status
+        - started_at
+        - trigger
+      properties:
+        id:
+          type: integer
+          format: int64
+        tier:
+          type: integer
+        status:
+          type: string
+        started_at:
+          type: string
+          format: date-time
+        ended_at:
+          type: string
+          format: date-time
+          nullable: true
+        cost_usd:
+          type: number
+          format: double
+          nullable: true
+        duration_ms:
+          type: integer
+          format: int64
+          nullable: true
+        trigger:
+          type: string
+          description: '"scheduled" or "manual".'
+        summary:
+          type: string
+          nullable: true
+          description: LLM-generated summary of the session response.
+
+    StatsResponse:
+      type: object
+      required:
+        - stats
+        - last_session
+        - next_run
+        - interval_seconds
+      properties:
+        stats:
+          $ref: "#/components/schemas/Stats"
+        last_session:
+          oneOf:
+            - $ref: "#/components/schemas/StatsSession"
+            - type: "null"
+          description: The most recent session, or null if none exist yet.
+        next_run:
+          type: string
+          format: date-time
+          description: Estimated time of the next scheduled run (now + interval).
+        interval_seconds:
+          type: integer
+          description: Monitoring loop interval in seconds.
 
     Error:
       type: object

--- a/internal/web/api_handlers.go
+++ b/internal/web/api_handlers.go
@@ -66,6 +66,37 @@ func (s *Server) handleAPIHealth(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, http.StatusOK, map[string]string{"status": "ok"})
 }
 
+// Governing: SPEC-0021 REQ "Dashboard Stats HUD" — GET /api/v1/stats
+// Governing: SPEC-0017 REQ-1 "API Route Registration", REQ-2 "JSON Content Type"
+// handleAPIStats returns the TL;DR HUD aggregate metrics plus the latest session and next
+// scheduled run, for consumption by external dashboards (e.g. Homepage). Unauthenticated,
+// mirroring GET /api/v1/health.
+func (s *Server) handleAPIStats(w http.ResponseWriter, r *http.Request) {
+	stats, err := s.db.GetDashboardStats()
+	if err != nil {
+		log.Printf("handleAPIStats: GetDashboardStats: %v", err)
+		writeError(w, http.StatusInternalServerError, "database error")
+		return
+	}
+
+	resp := APIStatsResponse{
+		Stats:           toAPIStats(stats),
+		NextRun:         time.Now().UTC().Add(time.Duration(s.cfg.Interval) * time.Second).Format(time.RFC3339),
+		IntervalSeconds: s.cfg.Interval,
+	}
+
+	// LatestSession powers the "Last Run" HUD row. A missing latest session is not an
+	// error — the field is simply null (e.g. on a fresh install with no runs yet).
+	if latest, err := s.db.LatestSession(); err != nil {
+		log.Printf("handleAPIStats: LatestSession: %v", err)
+	} else if latest != nil {
+		ls := toAPIStatsSession(*latest)
+		resp.LastSession = &ls
+	}
+
+	writeJSON(w, http.StatusOK, resp)
+}
+
 // Governing: SPEC-0017 REQ-3 "Sessions List Endpoint" — GET /api/v1/sessions with limit/offset pagination
 // Governing: SPEC-0017 REQ-18 "Pagination"
 // handleAPIListSessions returns a paginated list of sessions.

--- a/internal/web/api_test.go
+++ b/internal/web/api_test.go
@@ -45,6 +45,72 @@ func TestAPIHealthContentType(t *testing.T) {
 	}
 }
 
+// --- Stats Endpoint ---
+
+func TestAPIStatsEmpty(t *testing.T) {
+	e := newTestEnv(t)
+	req := httptest.NewRequest("GET", "/api/v1/stats", nil)
+	w := httptest.NewRecorder()
+	e.srv.mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+
+	var resp APIStatsResponse
+	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if resp.Stats.TotalRuns != 0 {
+		t.Fatalf("expected 0 total_runs, got %d", resp.Stats.TotalRuns)
+	}
+	if resp.LastSession != nil {
+		t.Fatalf("expected nil last_session, got %+v", resp.LastSession)
+	}
+	if resp.IntervalSeconds != e.srv.cfg.Interval {
+		t.Fatalf("expected interval_seconds %d, got %d", e.srv.cfg.Interval, resp.IntervalSeconds)
+	}
+	if resp.NextRun == "" {
+		t.Fatal("expected non-empty next_run")
+	}
+}
+
+func TestAPIStatsWithData(t *testing.T) {
+	e := newTestEnv(t)
+	insertTestSession(t, e, "completed")
+	insertTestSession(t, e, "running")
+
+	req := httptest.NewRequest("GET", "/api/v1/stats", nil)
+	w := httptest.NewRecorder()
+	e.srv.mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+
+	var resp APIStatsResponse
+	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if resp.Stats.TotalRuns != 2 {
+		t.Fatalf("expected 2 total_runs, got %d", resp.Stats.TotalRuns)
+	}
+	if resp.LastSession == nil {
+		t.Fatal("expected non-nil last_session")
+	}
+}
+
+func TestAPIStatsContentType(t *testing.T) {
+	e := newTestEnv(t)
+	req := httptest.NewRequest("GET", "/api/v1/stats", nil)
+	w := httptest.NewRecorder()
+	e.srv.mux.ServeHTTP(w, req)
+
+	if ct := w.Header().Get("Content-Type"); !strings.Contains(ct, "application/json") {
+		t.Fatalf("expected application/json, got %q", ct)
+	}
+}
+
 // --- Sessions Endpoints ---
 
 func TestAPIListSessionsEmpty(t *testing.T) {

--- a/internal/web/api_test.go
+++ b/internal/web/api_test.go
@@ -111,6 +111,35 @@ func TestAPIStatsContentType(t *testing.T) {
 	}
 }
 
+// Unhappy path: GetDashboardStats fails (here, the DB is closed) — the handler
+// must return 500 with a JSON error body rather than panicking or 200-ing.
+func TestAPIStatsDBError(t *testing.T) {
+	e := newTestEnv(t)
+	// Close the DB so the aggregate query fails. Cleanup double-closes harmlessly.
+	if err := e.srv.db.Close(); err != nil {
+		t.Fatalf("close db: %v", err)
+	}
+
+	req := httptest.NewRequest("GET", "/api/v1/stats", nil)
+	w := httptest.NewRecorder()
+	e.srv.mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusInternalServerError {
+		t.Fatalf("expected 500, got %d", w.Code)
+	}
+	if ct := w.Header().Get("Content-Type"); !strings.Contains(ct, "application/json") {
+		t.Fatalf("expected application/json, got %q", ct)
+	}
+
+	var resp map[string]string
+	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if resp["error"] == "" {
+		t.Fatal("expected non-empty error message in body")
+	}
+}
+
 // --- Sessions Endpoints ---
 
 func TestAPIListSessionsEmpty(t *testing.T) {

--- a/internal/web/api_types.go
+++ b/internal/web/api_types.go
@@ -100,6 +100,44 @@ type APIConfig struct {
 	ReposDir   string `json:"repos_dir"`
 }
 
+// Governing: SPEC-0021 REQ "Dashboard Stats HUD"; SPEC-0017 REQ-1 "API Route Registration"
+// APIStatsResponse is the JSON payload for GET /api/v1/stats. It exposes the same
+// aggregate metrics rendered in the TL;DR HUD so external dashboards (e.g. Homepage)
+// can poll them without scraping HTML.
+type APIStatsResponse struct {
+	Stats           APIStats         `json:"stats"`
+	LastSession     *APIStatsSession `json:"last_session"`
+	NextRun         string           `json:"next_run"`
+	IntervalSeconds int              `json:"interval_seconds"`
+}
+
+// Governing: SPEC-0021 REQ "Dashboard Stats HUD"
+// APIStats mirrors db.DashboardStats — the metrics shown in the TL;DR HUD.
+type APIStats struct {
+	TotalRuns      int     `json:"total_runs"`
+	Escalations    int     `json:"escalations"`
+	Remediations   int     `json:"remediations"`
+	SuccessRate    float64 `json:"success_rate"`
+	TotalCostUSD   float64 `json:"total_cost_usd"`
+	ActiveMemories int     `json:"active_memories"`
+	CriticalEvents int     `json:"critical_events"`
+	AvgDurationMs  int64   `json:"avg_duration_ms"`
+}
+
+// Governing: SPEC-0021 REQ "TL;DR Page Rendering" — the Last Run HUD row
+// APIStatsSession is a compact view of the most recent session for the stats endpoint.
+type APIStatsSession struct {
+	ID         int64    `json:"id"`
+	Tier       int      `json:"tier"`
+	Status     string   `json:"status"`
+	StartedAt  string   `json:"started_at"`
+	EndedAt    *string  `json:"ended_at"`
+	CostUSD    *float64 `json:"cost_usd"`
+	DurationMs *int64   `json:"duration_ms"`
+	Trigger    string   `json:"trigger"`
+	Summary    *string  `json:"summary"`
+}
+
 // Governing: SPEC-0023 REQ-9 — PR API types removed. PR operations are now skill-based (git-pr.md).
 
 // --- API Request Types ---
@@ -219,4 +257,31 @@ func toAPICooldowns(cooldowns []db.RecentCooldown) []APICooldown {
 		out[i] = toAPICooldown(c)
 	}
 	return out
+}
+
+func toAPIStats(s *db.DashboardStats) APIStats {
+	return APIStats{
+		TotalRuns:      s.TotalRuns,
+		Escalations:    s.Escalations,
+		Remediations:   s.Remediations,
+		SuccessRate:    s.SuccessRate,
+		TotalCostUSD:   s.TotalCostUSD,
+		ActiveMemories: s.ActiveMemories,
+		CriticalEvents: s.CriticalEvents,
+		AvgDurationMs:  s.AvgDurationMs,
+	}
+}
+
+func toAPIStatsSession(s db.Session) APIStatsSession {
+	return APIStatsSession{
+		ID:         s.ID,
+		Tier:       s.Tier,
+		Status:     s.Status,
+		StartedAt:  s.StartedAt,
+		EndedAt:    s.EndedAt,
+		CostUSD:    s.CostUSD,
+		DurationMs: s.DurationMs,
+		Trigger:    s.Trigger,
+		Summary:    s.Summary,
+	}
 }

--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -402,6 +402,8 @@ func (s *Server) registerRoutes() {
 	// Governing: SPEC-0017 REQ-14 "Health Endpoint"
 	// Governing: SPEC-0017 REQ-19 "Backward Compatibility" — HTML routes above remain unchanged; all endpoints under /api/v1 prefix
 	s.mux.HandleFunc("GET /api/v1/health", s.handleAPIHealth)
+	// Governing: SPEC-0021 REQ "Dashboard Stats HUD" — TL;DR HUD metrics for external dashboards (e.g. Homepage)
+	s.mux.HandleFunc("GET /api/v1/stats", s.handleAPIStats)
 	// Governing: SPEC-0017 REQ-3, REQ-4, REQ-5 — session list, detail, and trigger endpoints
 	s.mux.HandleFunc("GET /api/v1/sessions", s.handleAPIListSessions)
 	s.mux.HandleFunc("GET /api/v1/sessions/{id}", s.handleAPIGetSession)


### PR DESCRIPTION
## Summary

Adds an unauthenticated `GET /api/v1/stats` endpoint that exposes the dashboard's **TL;DR HUD** metrics as JSON, so external dashboards (e.g. [Homepage](https://gethomepage.dev)'s Custom API widget) can poll them directly instead of scraping HTML.

It serializes the existing `db.GetDashboardStats()` (the same data the HUD renders — single source of truth, no new queries) plus the latest session and the next scheduled run time. Style mirrors `GET /api/v1/health` (unauthenticated; per maintainer decision).

## Payload

```json
{
  "stats": { "total_runs": 142, "escalations": 9, "remediations": 3,
             "success_rate": 0.95, "total_cost_usd": 12.4831,
             "active_memories": 27, "critical_events": 1, "avg_duration_ms": 84210 },
  "last_session": { "id": 142, "status": "completed", "tier": 1, "summary": "…" },
  "next_run": "2026-06-21T11:00:00Z",
  "interval_seconds": 3600
}
```

`stats` is nested so Homepage's dot-notation field mapping works (e.g. `stats.total_runs`, `stats.success_rate`). `last_session` is `null` on a fresh install with no runs.

## Changes
- `internal/web/api_types.go` — `APIStatsResponse` / `APIStats` / `APIStatsSession` DTOs + conversions
- `internal/web/api_handlers.go` — `handleAPIStats` (reuses `GetDashboardStats` + `LatestSession`; missing latest session is not an error)
- `internal/web/server.go` — route registered next to `/api/v1/health`
- `api/openapi.yaml` — documents the path + `Stats`/`StatsSession`/`StatsResponse` schemas (keeps Swagger UI in sync)
- `internal/web/api_test.go` — empty / with-data / content-type tests

## Verification
- `go vet ./internal/web/...` — clean
- `go test ./internal/web/... -race` — **ok**
- `go build ./...` — succeeds
- `golangci-lint` — the changed files are clean. Note: there are pre-existing lint findings on `main` (`internal/web/handlers.go:726`, `internal/web/busy.go`, `internal/web/webhook_handler_test.go`) unrelated to this PR; CI may flag those independently.

## Governing artifacts
- SPEC-0021 (Dashboard Stats HUD), SPEC-0017 (REST API)

🤖 Generated with [Claude Code](https://claude.com/claude-code)