### PR TITLE
feat: upstream model auto-discovery for tier selection (SPEC-0035)

### DIFF
--- a/docs/openspec/specs/upstream-model-discovery/design.md
+++ b/docs/openspec/specs/upstream-model-discovery/design.md
@@ -59,9 +59,9 @@ This spec depends on SPEC-0008 (configuration) and SPEC-0017 (REST API config en
 
 ### Discovery source is the upstream gateway, read from the environment
 
-**Choice**: Build the discovery URL from `ANTHROPIC_BASE_URL` (env var), querying
-`${ANTHROPIC_BASE_URL}/v1/models`, authenticating with `ANTHROPIC_API_KEY` as
-`Authorization: Bearer`.
+**Choice**: Build the discovery target from `ANTHROPIC_BASE_URL` (env var), querying the
+gateway's models-list endpoint (`${ANTHROPIC_BASE_URL}/v1/models`), authenticating with
+`ANTHROPIC_API_KEY`.
 **Rationale**: This is exactly where the operator already configures the gateway the CLI
 routes through; reusing it guarantees the discovered list matches what the tiers will
 actually hit. No new configuration surface is required.
@@ -72,12 +72,33 @@ actually hit. No new configuration surface is required.
 - Query Claude Ops' own `/v1/models`: rejected — that returns synthetic tier IDs, not the
   upstream model inventory; it would be circular and wrong.
 
+### Use the Anthropic Go SDK for the models query (not a hand-rolled HTTP client)
+
+**Choice**: Fetch the model list via the official Anthropic Go SDK
+(`github.com/anthropics/anthropic-sdk-go`, already a project dependency) configured with
+`option.WithBaseURL(ANTHROPIC_BASE_URL)`, `option.WithAPIKey(ANTHROPIC_API_KEY)`, a
+bounded `option.WithHTTPClient` + `option.WithRequestTimeout`, and `option.WithMaxRetries(0)`,
+calling `client.Models.ListAutoPaging`.
+**Rationale**: Per reviewer request, use a maintained SDK rather than hand-rolling the
+HTTP call. The gateway is Anthropic-compatible (it is configured through
+`ANTHROPIC_BASE_URL`/`ANTHROPIC_API_KEY` and is the same endpoint the CLI subprocess
+hits), and the Anthropic SDK is already vendored, so this adds no new dependency and
+matches the client family used elsewhere. The SDK authenticates via the `x-api-key`
+header (which LiteLLM accepts for Anthropic-compatible routing) rather than
+`Authorization: Bearer`. Body-size bounding is preserved by wrapping the injected
+`http.Client`'s transport with a `LimitReader`-based round-tripper.
+**Alternatives considered**:
+- The OpenAI Go SDK (`github.com/openai/openai-go`): rejected — it would add a second,
+  redundant LLM SDK for a single list call when the Anthropic SDK is already present and
+  the endpoint is reached as an Anthropic-compatible gateway.
+- Keep the hand-rolled `http.Client` + manual JSON parsing: rejected per reviewer
+  feedback in favor of the maintained SDK.
+
 ### Dedicated discovery component with a cached, single-flight client
 
-**Choice**: Introduce a small discovery component (e.g. `internal/models` or a discovery
-type owned by the web `Server`) that owns an `http.Client` with a bounded timeout, a
-mutex-guarded cache holding `(modelIDs, lastRefreshed, available)`, and single-flight
-refresh.
+**Choice**: Introduce a small discovery component (`internal/models`) that owns a bounded
+`http.Client` (injected into the SDK), a mutex-guarded cache holding
+`(modelIDs, lastRefreshed, available)`, and single-flight refresh.
 **Rationale**: Centralizes timeout, auth, parsing, caching, and concurrency safety in one
 testable place; both the API handler and the HTML handler consume the same cache. Single
 -flight prevents refresh stampedes against the gateway.
@@ -149,7 +170,7 @@ flowchart LR
     API --> DISC
     HTML --> DISC
     DISC -->|cache hit within TTL| DISC
-    DISC -->|miss or refresh:\nAuthorization Bearer ANTHROPIC_API_KEY| GW
+    DISC -->|miss or refresh: SDK Models.List\nx-api-key ANTHROPIC_API_KEY| GW
     GW -->|"object:list, data:[id...]"| DISC
 ```
 
@@ -167,7 +188,7 @@ sequenceDiagram
         D-->>C: {models, lastRefreshed, available:true}
     else stale or forced
         D->>D: single-flight guard
-        D->>G: GET /v1/models (Bearer key, timeout, ctx)
+        D->>G: SDK Models.List (x-api-key, timeout, ctx)
         alt 2xx and parseable
             G-->>D: {data:[{id}...]}
             D->>D: dedupe+sort, set lastRefreshed
@@ -186,9 +207,9 @@ sequenceDiagram
   cache serves prior results, and degradation returns immediately with a fallback flag.
 - **Refresh stampede floods the gateway** → single-flight collapses concurrent refreshes
   to one in-flight upstream call; explicit refresh is the only TTL bypass.
-- **Leaking the upstream API key** → key is read from the environment only, sent solely in
-  the `Authorization` header, and excluded from logs, errors, API payloads, and rendered
-  HTML; structured logging avoids interpolating secrets.
+- **Leaking the upstream API key** → key is read from the environment only, passed solely
+  to the SDK (which sends it in the `x-api-key` header), and excluded from logs, errors,
+  API payloads, and rendered HTML; structured logging avoids interpolating secrets.
 - **Discovered list diverges from what the CLI can actually use** → discovery is advisory;
   free-text assignment is always allowed and the runtime CLI invocation is unchanged, so
   an unusable model fails exactly as it does today.

--- a/docs/openspec/specs/upstream-model-discovery/design.md
+++ b/docs/openspec/specs/upstream-model-discovery/design.md
@@ -1,0 +1,221 @@
+# Design: Upstream Model Auto-Discovery
+
+## Context
+
+Claude Ops invokes the Claude Code CLI as a subprocess for each escalation tier and
+passes the per-tier model via `--model` (SPEC-0010, ADR-0010). When the operator points
+Claude Ops at an upstream OpenAI/Anthropic-compatible gateway (LiteLLM) by setting the
+`ANTHROPIC_BASE_URL` environment variable (see `docker-compose.yaml`, `.env.example`,
+and README), the CLI's API traffic is routed through that gateway, which can in turn
+route to many backing models.
+
+Currently the tier model fields — `tier1_model`, `tier2_model`, `tier3_model` — are
+free-text strings in `internal/config/config.go` (`Config` struct, loaded via viper).
+They are read and written through:
+
+- The REST API: `handleAPIGetConfig` / `handleAPIUpdateConfig` in
+  `internal/web/api_handlers.go`, with DTOs `APIConfig` / `APIUpdateConfigRequest` in
+  `internal/web/api_types.go` (SPEC-0017 REQ-12/REQ-13).
+- The HTML config page: `handleConfigGet` / `handleConfigPost` in
+  `internal/web/handlers.go`, rendering `templates/config.html` (SPEC-0008 REQ-10).
+
+Operators must know exact model identifiers to type them in. LiteLLM (and any
+OpenAI-compatible gateway) exposes `GET /v1/models` listing the routable models, which we
+can query to populate a selectable list.
+
+A critical disambiguation: Claude Ops ALSO serves its own OpenAI-compatible
+`GET /v1/models` endpoint (`handleModels` in `internal/web/chat_handler.go`, SPEC-0024 /
+ADR-0020) advertising the synthetic `claude-ops`, `claude-ops-tier1/2/3` identifiers used
+by chat clients. That is a SERVED endpoint for inbound chat clients. This capability adds
+a CONSUMED query against the operator's UPSTREAM gateway. They are unrelated and must not
+be merged.
+
+This spec depends on SPEC-0008 (configuration) and SPEC-0017 (REST API config endpoints).
+
+## Goals / Non-Goals
+
+### Goals
+
+- Discover the models a configured upstream gateway can route to, via
+  `${ANTHROPIC_BASE_URL}/v1/models`.
+- Expose the discovered list through the config API and the dashboard config page so
+  operators pick from a list instead of typing blind.
+- Let operators assign any discovered (or manually typed) model to any tier.
+- Cache discovered models with a TTL plus on-demand refresh; keep upstream load low.
+- Fail safe: discovery problems never break config rendering, retrieval, or saving.
+
+### Non-Goals
+
+- Validating that a chosen model actually works end-to-end (the gateway/CLI surface that
+  at runtime; an invalid model fails at invocation, as it does today).
+- Tracking the upstream base URL or credential as new managed config fields — they remain
+  process environment variables consumed at request time. (A future spec may promote
+  them to managed config.)
+- Changing Claude Ops' own served `/v1/models` endpoint (SPEC-0024).
+- Per-model metadata beyond the identifier (context window, pricing, capabilities) — out
+  of scope for this iteration; only `id` is consumed.
+
+## Decisions
+
+### Discovery source is the upstream gateway, read from the environment
+
+**Choice**: Build the discovery URL from `ANTHROPIC_BASE_URL` (env var), querying
+`${ANTHROPIC_BASE_URL}/v1/models`, authenticating with `ANTHROPIC_API_KEY` as
+`Authorization: Bearer`.
+**Rationale**: This is exactly where the operator already configures the gateway the CLI
+routes through; reusing it guarantees the discovered list matches what the tiers will
+actually hit. No new configuration surface is required.
+**Alternatives considered**:
+- Promote base URL / key into the `Config` struct now: rejected — larger change, and the
+  env vars are the established source of truth consumed by the CLI subprocess; promoting
+  them is a separable decision.
+- Query Claude Ops' own `/v1/models`: rejected — that returns synthetic tier IDs, not the
+  upstream model inventory; it would be circular and wrong.
+
+### Dedicated discovery component with a cached, single-flight client
+
+**Choice**: Introduce a small discovery component (e.g. `internal/models` or a discovery
+type owned by the web `Server`) that owns an `http.Client` with a bounded timeout, a
+mutex-guarded cache holding `(modelIDs, lastRefreshed, available)`, and single-flight
+refresh.
+**Rationale**: Centralizes timeout, auth, parsing, caching, and concurrency safety in one
+testable place; both the API handler and the HTML handler consume the same cache. Single
+-flight prevents refresh stampedes against the gateway.
+**Alternatives considered**:
+- Query on every config render: rejected — adds latency and upstream load to every page
+  view and API read.
+- Background poller only (no lazy refresh): rejected — wastes upstream calls when the
+  config page is rarely viewed; lazy-on-access with TTL is simpler and sufficient. A
+  background refresh MAY be layered in later without changing the contract.
+
+### New API endpoints rather than folding into GET /api/v1/config
+
+**Choice**: Add `GET /api/v1/models/available` (with `?refresh=true`) and
+`POST /api/v1/models/available/refresh`, separate from `GET /api/v1/config`.
+**Rationale**: Keeps the config payload stable (SPEC-0017 consumers unaffected), lets the
+discovered list and its freshness metadata evolve independently, and gives the UI a clean
+endpoint to refresh without re-fetching all config. Discovery latency/failure is isolated
+from the config read path. Handlers should follow the existing `handleAPI*` naming
+convention in `internal/web/api_handlers.go` (e.g. `handleAPIModelsAvailable`).
+
+Note on auth baseline: `internal/web/server.go` currently registers `/api/v1/*` routes
+with no auth/security-header/CSRF middleware, so the new endpoints inherit the same
+(currently unauthenticated) baseline as `/api/v1/config`. The spec's security
+requirements define the target regime; they do not assume reusable middleware exists
+today. Establishing that middleware project-wide is a separable effort.
+**Alternatives considered**:
+- Embed `available_models` in `APIConfig`: rejected — couples config reads to upstream
+  latency and bloats a stable DTO; a failed discovery shouldn't perturb config reads.
+
+### Free-text fallback is always permitted
+
+**Choice**: Tier model fields remain free-text-capable; discovery only augments the UI
+with a dropdown and the API with a list. Any value (discovered or not) is accepted and
+persisted.
+**Rationale**: Preserves existing behavior, supports gateways that under-report models,
+private/aliased models, and air-gapped setups with no `ANTHROPIC_BASE_URL`. Discovery is
+an aid, never a gate.
+
+### Graceful degradation returns 200 with `discovery_available: false`
+
+**Choice**: When discovery can't run (no base URL, timeout, non-2xx, parse error), the
+available-models endpoint returns `200` with an empty list and
+`discovery_available: false` instead of an error status; the HTML page falls back to
+free-text inputs.
+**Rationale**: Discovery is best-effort metadata. Returning an error status would push
+failure handling onto every consumer and risk breaking the config page. A clear flag lets
+clients decide how to present the fallback.
+
+## Architecture
+
+The web `Server` gains a model-discovery dependency. The API and HTML config handlers
+read the cached discovered list through it; the cache lazily refreshes from the upstream
+gateway on TTL expiry or explicit refresh.
+
+```mermaid
+flowchart LR
+    subgraph Browser/Client
+        UI[Config page / API client]
+    end
+    subgraph ClaudeOps[Claude Ops web.Server]
+        API[handleAPIModelsAvailable\nGET /api/v1/models/available]
+        HTML[handleConfigGet\n templates/config.html]
+        DISC[ModelDiscovery\ncache + single-flight\nhttp.Client timeout]
+    end
+    GW[(Upstream Gateway\nANTHROPIC_BASE_URL\n/v1/models)]
+
+    UI -->|GET available / refresh| API
+    UI -->|GET config page| HTML
+    API --> DISC
+    HTML --> DISC
+    DISC -->|cache hit within TTL| DISC
+    DISC -->|miss or refresh:\nAuthorization Bearer ANTHROPIC_API_KEY| GW
+    GW -->|"object:list, data:[id...]"| DISC
+```
+
+Refresh / cache decision flow for a single access:
+
+```mermaid
+sequenceDiagram
+    participant C as Client/Handler
+    participant D as ModelDiscovery
+    participant G as Upstream Gateway
+    C->>D: AvailableModels(forceRefresh?)
+    alt ANTHROPIC_BASE_URL unset
+        D-->>C: {models:[], available:false}
+    else cache fresh and not forced
+        D-->>C: {models, lastRefreshed, available:true}
+    else stale or forced
+        D->>D: single-flight guard
+        D->>G: GET /v1/models (Bearer key, timeout, ctx)
+        alt 2xx and parseable
+            G-->>D: {data:[{id}...]}
+            D->>D: dedupe+sort, set lastRefreshed
+            D-->>C: {models, lastRefreshed, available:true}
+        else timeout / non-2xx / parse error
+            G-->>D: error
+            D->>D: log with context (no secret)
+            D-->>C: {prior models or [], available:false}
+        end
+    end
+```
+
+## Risks / Trade-offs
+
+- **Upstream gateway slow or down stalls config UX** → bounded HTTP timeout (default ~5s),
+  cache serves prior results, and degradation returns immediately with a fallback flag.
+- **Refresh stampede floods the gateway** → single-flight collapses concurrent refreshes
+  to one in-flight upstream call; explicit refresh is the only TTL bypass.
+- **Leaking the upstream API key** → key is read from the environment only, sent solely in
+  the `Authorization` header, and excluded from logs, errors, API payloads, and rendered
+  HTML; structured logging avoids interpolating secrets.
+- **Discovered list diverges from what the CLI can actually use** → discovery is advisory;
+  free-text assignment is always allowed and the runtime CLI invocation is unchanged, so
+  an unusable model fails exactly as it does today.
+- **Oversized/malicious upstream body** → response read is bounded to a maximum size;
+  overflow is treated as a parse failure (discovery unavailable).
+- **New endpoints widen attack surface** → both require the same auth as `/api/v1/config`;
+  the upstream target is derived only from `ANTHROPIC_BASE_URL`, never from request input.
+
+## Migration Plan
+
+Additive; no data migration. Deployment steps:
+
+1. Ship the discovery component, the two new API endpoints, and the config-page dropdown
+   with refresh control. Behavior is unchanged when `ANTHROPIC_BASE_URL` is unset.
+2. Operators with a gateway configured see populated dropdowns automatically on next
+   config-page load; no action required.
+3. Rollback is safe: removing the feature reverts the config page to free-text inputs and
+   drops the new endpoints. Persisted tier model values (free-text strings) are unaffected
+   since the storage format is unchanged.
+
+## Open Questions
+
+- Should the upstream base URL and key eventually become managed `Config` fields (so they
+  can be changed from the dashboard without a restart), rather than env-only? Deferred to
+  a follow-up spec.
+- Should a background refresh run on the existing run interval to keep the cache warm, or
+  is lazy-on-access sufficient? Lazy is the initial choice; revisit if operators report
+  staleness.
+- Should discovery surface per-model metadata (context window, pricing) when the gateway
+  provides it, to aid tier selection? Out of scope for this iteration.

--- a/docs/openspec/specs/upstream-model-discovery/spec.md
+++ b/docs/openspec/specs/upstream-model-discovery/spec.md
@@ -1,5 +1,5 @@
 ---
-status: draft
+status: accepted
 date: 2026-06-21
 requires: [SPEC-0008, SPEC-0017]
 ---

--- a/docs/openspec/specs/upstream-model-discovery/spec.md
+++ b/docs/openspec/specs/upstream-model-discovery/spec.md
@@ -1,0 +1,404 @@
+---
+status: draft
+date: 2026-06-21
+requires: [SPEC-0008, SPEC-0017]
+---
+
+# SPEC-0035: Upstream Model Auto-Discovery
+
+## Overview
+
+Claude Ops routes its tiered agents through an upstream OpenAI/Anthropic-compatible
+LLM gateway (typically [LiteLLM](https://github.com/BerriAI/litellm)) configured via
+the `ANTHROPIC_BASE_URL` environment variable. That gateway can route to many backing
+models (Gemini, DeepSeek, Claude, etc.) and exposes the routable set through an
+OpenAI-style models endpoint (`GET /v1/models`).
+
+Today the per-tier model fields (`tier1_model`, `tier2_model`, `tier3_model` — see
+SPEC-0008 and SPEC-0017) are free-text strings: the operator must know and type model
+identifiers blindly. This capability adds **auto-discovery** of the models available
+on the upstream gateway and surfaces that list through the configuration API and the
+dashboard configuration page, so the operator can assign any discovered model to any
+escalation tier from a selectable list. When discovery is unavailable, the system
+degrades gracefully to the existing free-text behavior.
+
+This discovery SOURCE — the upstream gateway at `${ANTHROPIC_BASE_URL}/v1/models` — is
+distinct from Claude Ops' OWN OpenAI-compatible models endpoint (`GET /v1/models`,
+governed by SPEC-0024 / ADR-0020), which advertises the synthetic `claude-ops`,
+`claude-ops-tier1/2/3` identifiers. The two MUST NOT be conflated. Tier model
+identifiers discovered here are passed to the Claude Code CLI subprocess via `--model`
+per SPEC-0010.
+
+## Requirements
+
+### Requirement: Upstream Model Query
+
+The system MUST be able to query the upstream gateway's models endpoint to enumerate
+the models it can route to.
+
+- The system MUST issue an HTTP `GET` request to `${ANTHROPIC_BASE_URL}/v1/models`,
+  derived from the configured `ANTHROPIC_BASE_URL`. Path joining MUST be tolerant of a
+  trailing slash on the base URL.
+- The system MUST parse the OpenAI-style response body of the form
+  `{"object":"list","data":[{"id":"...","object":"model",...}]}` and extract the `id`
+  field of each entry into a list of model identifiers.
+- The system MUST authenticate the request using the upstream credential
+  (`ANTHROPIC_API_KEY`) by sending an `Authorization: Bearer <key>` header. If no key
+  is configured, the request MUST still be attempted (some gateways are unauthenticated)
+  but the absence MUST NOT cause a panic.
+- A bounded HTTP timeout MUST apply to the request. The timeout SHOULD default to a
+  small number of seconds (RECOMMENDED: 5 seconds) so a slow or unreachable gateway
+  cannot stall configuration rendering.
+- Returned model identifiers SHOULD be de-duplicated and presented in a stable
+  (e.g. sorted) order.
+
+#### Scenario: Gateway returns a model list
+
+- **WHEN** `ANTHROPIC_BASE_URL` is set and the gateway responds `200` with
+  `{"object":"list","data":[{"id":"gemini-2.5-pro"},{"id":"deepseek-chat"},{"id":"claude-opus-4-8"}]}`
+- **THEN** the system extracts `["claude-opus-4-8","deepseek-chat","gemini-2.5-pro"]`
+  (de-duplicated, sorted) as the discovered model list
+
+#### Scenario: Trailing slash on base URL
+
+- **WHEN** `ANTHROPIC_BASE_URL` is `https://litellm.example.com/`
+- **THEN** the system queries `https://litellm.example.com/v1/models` without a doubled
+  slash
+
+#### Scenario: Upstream credential is sent
+
+- **WHEN** the system queries the gateway and `ANTHROPIC_API_KEY` is set
+- **THEN** the outgoing request carries an `Authorization: Bearer <key>` header
+
+### Requirement: Discovered Model Caching and Refresh
+
+The system SHOULD cache the discovered model list rather than querying the upstream
+gateway on every configuration render or API request.
+
+- The cached list MUST be stored with a last-refreshed timestamp and a configurable
+  time-to-live (TTL). The TTL SHOULD default to a few minutes (RECOMMENDED: 5 minutes).
+- A cached list whose age is within the TTL MUST be served without contacting the
+  upstream gateway.
+- When the cached list is older than the TTL, the system SHOULD refresh it from the
+  upstream gateway on the next access.
+- The system MUST support an explicit, on-demand refresh that bypasses the TTL and
+  re-queries the upstream gateway immediately.
+- Cache access MUST be safe for concurrent use (the configuration API, the dashboard,
+  and any background refresh may read or update the cache simultaneously).
+
+#### Scenario: Cache hit within TTL
+
+- **WHEN** the model list was refreshed 30 seconds ago, the TTL is 5 minutes, and a
+  client requests the available models
+- **THEN** the system returns the cached list without issuing an upstream request
+
+#### Scenario: Cache expiry triggers refresh
+
+- **WHEN** the model list was refreshed 10 minutes ago, the TTL is 5 minutes, and a
+  client requests the available models
+- **THEN** the system re-queries the upstream gateway and updates the cache and its
+  last-refreshed timestamp
+
+#### Scenario: Explicit refresh bypasses TTL
+
+- **WHEN** an operator triggers an explicit refresh while a within-TTL cached list
+  exists
+- **THEN** the system re-queries the upstream gateway immediately and replaces the
+  cached list
+
+### Requirement: Available Models API Endpoint
+
+The configuration API MUST expose the discovered model list so clients can present a
+selectable list.
+
+- The system MUST provide `GET /api/v1/models/available` returning a JSON object
+  containing the discovered model identifiers and cache-freshness metadata
+  (at minimum: the list of model IDs, the last-refreshed timestamp, and a flag or field
+  indicating whether discovery is currently available).
+- The endpoint MUST support an explicit refresh, either via a query parameter
+  (e.g. `?refresh=true`) on the `GET` or a companion `POST /api/v1/models/available/refresh`,
+  that forces an upstream re-query before responding.
+- When discovery is unavailable (see Graceful Degradation), the endpoint MUST still
+  return `200` with an empty model list and a field indicating discovery is unavailable,
+  rather than returning an error status.
+- Responses MUST set `Content-Type: application/json` per SPEC-0017 REQ-2.
+
+| Method | Path | Auth | Description |
+|--------|------|------|-------------|
+| GET | /api/v1/models/available | Required | List discovered upstream models with cache metadata |
+| POST | /api/v1/models/available/refresh | Required | Force an upstream re-query and return the refreshed list |
+
+#### Scenario: List available models
+
+- **WHEN** an authenticated client sends `GET /api/v1/models/available` and discovery
+  succeeded
+- **THEN** the response is `200` with `Content-Type: application/json` containing the
+  discovered model IDs, a `last_refreshed` timestamp, and `discovery_available: true`
+
+#### Scenario: Discovery unavailable returns empty list, not an error
+
+- **WHEN** `ANTHROPIC_BASE_URL` is unset and a client sends
+  `GET /api/v1/models/available`
+- **THEN** the response is `200` with an empty model list and `discovery_available: false`
+
+### Requirement: Tier Model Assignment from Discovered Models
+
+The operator MUST be able to assign any discovered model identifier to `tier1_model`,
+`tier2_model`, or `tier3_model`.
+
+- The configuration update paths (`PUT /api/v1/config` per SPEC-0017 REQ-13 and the
+  HTML config form `POST` per SPEC-0008 REQ-10) MUST accept any discovered model ID as
+  the value for a tier model field and persist it.
+- Assigning a model ID that is NOT in the discovered list (e.g. a manually typed value)
+  MUST still be allowed and persisted — discovery is an aid, not a constraint
+  (see Graceful Degradation).
+- A persisted tier model assignment MUST be used by the Claude Code CLI subprocess via
+  `--model` for that tier per SPEC-0010, with no behavioral change to how the value is
+  consumed.
+
+#### Scenario: Assign a discovered model to a tier
+
+- **WHEN** the operator selects `gemini-2.5-pro` (a discovered model) for `tier1_model`
+  and saves the configuration
+- **THEN** `tier1_model` is persisted as `gemini-2.5-pro` and used for Tier 1 CLI
+  invocations
+
+#### Scenario: Assign a model not in the discovered list
+
+- **WHEN** the operator submits `some-private-model` as `tier3_model` and that ID is
+  not in the discovered list
+- **THEN** the value is accepted and persisted without error
+
+### Requirement: Configuration UI Model Selection
+
+The dashboard configuration page SHOULD present the discovered models as a selectable
+list for the per-tier model fields.
+
+- The config page SHOULD render the tier1/tier2/tier3 model fields as a selectable
+  control (e.g. a dropdown populated from the discovered model list) when discovery is
+  available.
+- The currently configured value for each tier MUST be pre-selected, and if the current
+  value is not among the discovered models, it MUST still be displayed and remain the
+  selected/entered value.
+- The page SHOULD provide a control to refresh the discovered model list on demand.
+- When discovery is unavailable, the page MUST fall back to free-text input for the tier
+  model fields (see Graceful Degradation).
+
+#### Scenario: Dropdown populated from discovered models
+
+- **WHEN** discovery is available and the operator opens the config page
+- **THEN** each tier model field offers the discovered models as selectable options with
+  the current value pre-selected
+
+#### Scenario: Current non-discovered value preserved in UI
+
+- **WHEN** `tier2_model` is set to a value not present in the discovered list and the
+  operator opens the config page
+- **THEN** the current `tier2_model` value is shown as the selected/entered value and is
+  not silently dropped
+
+#### Scenario: Refresh control re-queries the gateway
+
+- **WHEN** the operator activates the refresh control on the config page
+- **THEN** the discovered model list is re-queried and the selectable options update
+
+### Requirement: Graceful Degradation
+
+The system MUST degrade gracefully when upstream model discovery cannot be performed,
+and discovery failures MUST NOT break configuration rendering, retrieval, or saving.
+
+- When `ANTHROPIC_BASE_URL` is unset, the system MUST treat discovery as unavailable
+  and MUST NOT attempt an upstream request.
+- When the upstream request fails, times out, returns a non-2xx status, or returns an
+  unparseable body, the system MUST treat discovery as unavailable for that attempt and
+  MUST surface the existing free-text configuration behavior.
+- Rendering the dashboard config page and reading `GET /api/v1/config` MUST succeed even
+  when discovery is unavailable.
+- Saving configuration (HTML form `POST` and `PUT /api/v1/config`) MUST succeed even
+  when discovery is unavailable, including persisting tier model values that are not in
+  any discovered list.
+
+#### Scenario: Base URL unset
+
+- **WHEN** `ANTHROPIC_BASE_URL` is not configured
+- **THEN** no upstream request is attempted, the config page renders with free-text tier
+  model inputs, and configuration can still be saved
+
+#### Scenario: Upstream timeout does not break config rendering
+
+- **WHEN** the upstream gateway does not respond within the configured timeout while the
+  operator loads the config page
+- **THEN** the config page still renders (falling back to free-text inputs) and no error
+  is shown that prevents saving
+
+#### Scenario: Non-2xx upstream response
+
+- **WHEN** the upstream gateway responds `503` to the models query
+- **THEN** discovery is treated as unavailable for that attempt and the most recent
+  successfully-cached list, if present, otherwise the free-text fallback, is used;
+  configuration remains saveable
+
+### Requirement: Upstream Call Security and Error Handling
+
+The upstream discovery call MUST handle authentication, timeouts, and errors safely.
+
+- The upstream `ANTHROPIC_API_KEY` MUST NOT be written to logs, error messages, API
+  responses, or rendered HTML at any point.
+- Discovery errors MUST be wrapped with contextual information at layer boundaries
+  (e.g. "discover upstream models: request failed: ...") and MUST NOT be silently
+  swallowed — each error MUST be returned to the caller or logged with sufficient
+  (non-secret) context.
+- Structured logging MUST be used for discovery error reporting (key-value pairs, not
+  string interpolation of secrets).
+- The discovery HTTP client MUST enforce the bounded timeout from the Upstream Model
+  Query requirement and MUST use context propagation for cancellation across the request
+  boundary.
+
+#### Scenario: API key never appears in logs or responses
+
+- **WHEN** any discovery outcome occurs (success, timeout, non-2xx, parse error)
+- **THEN** the upstream API key value does not appear in any log line, error message,
+  API response, or rendered page
+
+#### Scenario: Discovery error is logged with context, not swallowed
+
+- **WHEN** the upstream request returns a connection error
+- **THEN** the error is logged with contextual, non-secret detail (e.g. the failing
+  operation and status) and discovery is reported as unavailable rather than failing
+  silently
+
+## Security Requirements
+
+This capability adds HTTP endpoints and makes outbound authenticated requests; the
+following security requirements are MANDATORY.
+
+> **Baseline note:** As of this writing the Claude Ops web layer
+> (`internal/web/server.go`) wires `/api/v1/*` routes with no authentication,
+> security-header, or CSRF middleware — the existing `/api/v1/config` endpoints are
+> effectively unauthenticated. The requirements below define the regime the new
+> endpoints MUST conform to; an implementer MUST NOT assume reusable auth/header/CSRF
+> middleware already exists. Where a requirement says "the same regime as existing
+> endpoints," it means: do not weaken whatever baseline is in place, and apply the
+> protection if/when that baseline is established.
+
+### Requirement: Authentication
+
+The new `/api/v1/models/available` and `/api/v1/models/available/refresh` endpoints MUST
+follow the same authentication regime as the existing `/api/v1/config` endpoints
+(SPEC-0017) and MUST NOT be more permissive than those endpoints. They MUST NOT be
+publicly accessible beyond whatever access the rest of `/api/v1/config` already permits,
+since they reveal the operator's upstream model inventory.
+
+| Method | Path | Auth | Justification |
+|--------|------|------|---------------|
+| GET | /api/v1/models/available | Required | Reveals upstream model inventory; same regime as /api/v1/config |
+| POST | /api/v1/models/available/refresh | Required | Triggers an outbound authenticated upstream call |
+
+#### Scenario: Unauthenticated request is rejected
+
+- **WHEN** an unauthenticated client requests `GET /api/v1/models/available` and the
+  deployment requires API authentication
+- **THEN** the request is rejected with the same auth failure response as other
+  `/api/v1/*` endpoints
+
+### Requirement: Rate Limiting
+
+The explicit-refresh path MUST be protected against abuse so it cannot be used to flood
+the upstream gateway with model queries.
+
+- On-demand refresh requests MUST be bounded such that repeated rapid refreshes collapse
+  to at most one in-flight upstream query (e.g. single-flight) or are otherwise rate
+  limited.
+
+#### Scenario: Rapid refreshes collapse to one upstream call
+
+- **WHEN** multiple refresh requests arrive within a very short window
+- **THEN** at most one upstream model query is in flight at a time and the others receive
+  its result
+
+### Requirement: Request Body Size Limits
+
+The `POST /api/v1/models/available/refresh` endpoint MUST bound any request body it
+reads, consistent with other API write endpoints, to avoid unbounded memory use. The
+response body read from the upstream gateway MUST also be bounded to a reasonable maximum
+size.
+
+#### Scenario: Oversized upstream response is bounded
+
+- **WHEN** the upstream gateway returns an unexpectedly large response body
+- **THEN** the system reads at most a bounded number of bytes and treats anything beyond
+  the bound as a parse failure (discovery unavailable), without exhausting memory
+
+### Requirement: Security Headers
+
+Responses from the new endpoints MUST carry the same baseline security headers applied to
+the rest of the Claude Ops HTTP surface (no weakening of existing header policy).
+
+#### Scenario: Baseline headers present
+
+- **WHEN** a client receives a response from `/api/v1/models/available`
+- **THEN** the response carries the same baseline security headers as other API responses
+
+### Requirement: CSRF Protection
+
+The config form `POST` and any UI-triggered refresh that mutates server state MUST be
+protected by the same CSRF protection as the existing config form (SPEC-0008). The
+read-only `GET /api/v1/models/available` is not state-mutating and does not require CSRF
+tokens.
+
+#### Scenario: UI refresh honors existing CSRF protection
+
+- **WHEN** a UI-initiated refresh mutates server-side cache state via a browser form/POST
+- **THEN** it is subject to the same CSRF protection as the existing config form
+
+### Requirement: Redirect Validation
+
+This capability introduces no user-controlled redirects. The upstream request target is
+derived solely from the operator-configured `ANTHROPIC_BASE_URL`; the system MUST NOT
+follow a redirect to a host other than the configured base URL host without bound, and
+MUST NOT take a redirect target from request input.
+
+#### Scenario: Upstream target is not request-controlled
+
+- **WHEN** a client calls the available-models endpoints
+- **THEN** the upstream URL is computed only from `ANTHROPIC_BASE_URL`, never from client
+  input
+
+## Accessibility Requirements
+
+This spec involves user-facing UI (the dashboard config page). The following
+accessibility requirements are MANDATORY per WCAG 2.1 AA.
+
+### WCAG 2.1 AA Compliance
+
+All UI components produced by this spec MUST meet WCAG 2.1 Level AA conformance as the
+minimum accessibility target.
+
+### ARIA Landmarks
+
+The config page structure MUST preserve existing ARIA landmark roles (`role="banner"`,
+`role="navigation"`, `role="main"`, `role="contentinfo"`); the model-selection controls
+MUST live within the `role="main"` content area.
+
+### Icon-Only Controls
+
+The refresh control, if rendered as an icon-only button, MUST include an `aria-label`
+describing its purpose (e.g. `aria-label="Refresh available models"`).
+
+### Dynamic Content Regions
+
+The model-selection list and any "last refreshed" status that updates without a full page
+reload (e.g. via HTMX swap) MUST use an `aria-live="polite"` region so assistive
+technology announces the update.
+
+### Keyboard Navigation
+
+The model-selection control and the refresh control MUST be fully keyboard operable:
+logical tab order, Enter/Space to activate the refresh control, and standard keyboard
+interaction for the selection control (arrow keys for a native/ARIA listbox).
+
+### Focus Management
+
+After an on-demand refresh updates the model list in place, focus MUST NOT be lost — it
+MUST remain on or return to the control that initiated the refresh (or a sensible
+adjacent control).

--- a/docs/openspec/specs/upstream-model-discovery/spec.md
+++ b/docs/openspec/specs/upstream-model-discovery/spec.md
@@ -8,11 +8,11 @@ requires: [SPEC-0008, SPEC-0017]
 
 ## Overview
 
-Claude Ops routes its tiered agents through an upstream OpenAI/Anthropic-compatible
-LLM gateway (typically [LiteLLM](https://github.com/BerriAI/litellm)) configured via
-the `ANTHROPIC_BASE_URL` environment variable. That gateway can route to many backing
-models (Gemini, DeepSeek, Claude, etc.) and exposes the routable set through an
-OpenAI-style models endpoint (`GET /v1/models`).
+Claude Ops routes its tiered agents through an upstream Anthropic-compatible LLM
+gateway (typically [LiteLLM](https://github.com/BerriAI/litellm)) configured via the
+`ANTHROPIC_BASE_URL` environment variable. That gateway can route to many backing
+models (Gemini, DeepSeek, Claude, etc.) and exposes the routable set through a
+models-list endpoint (`GET /v1/models`).
 
 Today the per-tier model fields (`tier1_model`, `tier2_model`, `tier3_model` — see
 SPEC-0008 and SPEC-0017) are free-text strings: the operator must know and type model
@@ -36,16 +36,17 @@ per SPEC-0010.
 The system MUST be able to query the upstream gateway's models endpoint to enumerate
 the models it can route to.
 
-- The system MUST issue an HTTP `GET` request to `${ANTHROPIC_BASE_URL}/v1/models`,
-  derived from the configured `ANTHROPIC_BASE_URL`. Path joining MUST be tolerant of a
-  trailing slash on the base URL.
-- The system MUST parse the OpenAI-style response body of the form
-  `{"object":"list","data":[{"id":"...","object":"model",...}]}` and extract the `id`
-  field of each entry into a list of model identifiers.
+- The system MUST query the upstream gateway's models endpoint at
+  `${ANTHROPIC_BASE_URL}/v1/models`, derived from the configured `ANTHROPIC_BASE_URL`.
+  Path joining MUST be tolerant of a trailing slash on the base URL. (The
+  implementation queries this endpoint via the Anthropic Go SDK's models-list call,
+  configured with the base URL — see design.md.)
+- The system MUST parse the gateway's models-list response (a JSON object whose `data`
+  array contains entries each with an `id` field) and extract the `id` of each entry
+  into a list of model identifiers.
 - The system MUST authenticate the request using the upstream credential
-  (`ANTHROPIC_API_KEY`) by sending an `Authorization: Bearer <key>` header. If no key
-  is configured, the request MUST still be attempted (some gateways are unauthenticated)
-  but the absence MUST NOT cause a panic.
+  (`ANTHROPIC_API_KEY`). If no key is configured, the request MUST still be attempted
+  (some gateways are unauthenticated) but the absence MUST NOT cause a panic.
 - A bounded HTTP timeout MUST apply to the request. The timeout SHOULD default to a
   small number of seconds (RECOMMENDED: 5 seconds) so a slow or unreachable gateway
   cannot stall configuration rendering.
@@ -54,8 +55,8 @@ the models it can route to.
 
 #### Scenario: Gateway returns a model list
 
-- **WHEN** `ANTHROPIC_BASE_URL` is set and the gateway responds `200` with
-  `{"object":"list","data":[{"id":"gemini-2.5-pro"},{"id":"deepseek-chat"},{"id":"claude-opus-4-8"}]}`
+- **WHEN** `ANTHROPIC_BASE_URL` is set and the gateway responds `200` with a models-list
+  body whose `data` array is `[{"id":"gemini-2.5-pro"},{"id":"deepseek-chat"},{"id":"claude-opus-4-8"}]`
 - **THEN** the system extracts `["claude-opus-4-8","deepseek-chat","gemini-2.5-pro"]`
   (de-duplicated, sorted) as the discovered model list
 
@@ -68,7 +69,8 @@ the models it can route to.
 #### Scenario: Upstream credential is sent
 
 - **WHEN** the system queries the gateway and `ANTHROPIC_API_KEY` is set
-- **THEN** the outgoing request carries an `Authorization: Bearer <key>` header
+- **THEN** the outgoing request carries the upstream credential in its authentication
+  header (the Anthropic SDK sends `x-api-key`)
 
 ### Requirement: Discovered Model Caching and Refresh
 

--- a/internal/models/discovery.go
+++ b/internal/models/discovery.go
@@ -1,17 +1,20 @@
 // Package models discovers the set of LLM models available on the upstream
-// OpenAI/Anthropic-compatible gateway (e.g. LiteLLM) that Claude Ops routes
-// through. The gateway is configured via the ANTHROPIC_BASE_URL environment
-// variable and authenticated with ANTHROPIC_API_KEY.
+// Anthropic-compatible gateway (e.g. LiteLLM) that Claude Ops routes through.
+// The gateway is configured via the ANTHROPIC_BASE_URL environment variable and
+// authenticated with ANTHROPIC_API_KEY.
+//
+// Discovery uses the official Anthropic Go SDK (already a project dependency, and
+// the same client family Claude Ops uses elsewhere) pointed at the configured
+// base URL: client.Models.List. This avoids a hand-rolled HTTP client and a
+// redundant second LLM SDK.
 //
 // Governing: SPEC-0035 (Upstream Model Auto-Discovery). The discovery SOURCE is
-// the upstream gateway's GET ${ANTHROPIC_BASE_URL}/v1/models — distinct from
-// Claude Ops' OWN served /v1/models endpoint (SPEC-0024 / ADR-0020).
+// the upstream gateway's models endpoint — distinct from Claude Ops' OWN served
+// /v1/models endpoint (SPEC-0024 / ADR-0020).
 package models
 
 import (
 	"context"
-	"encoding/json"
-	"fmt"
 	"io"
 	"log"
 	"net/http"
@@ -19,6 +22,9 @@ import (
 	"strings"
 	"sync"
 	"time"
+
+	"github.com/anthropics/anthropic-sdk-go"
+	"github.com/anthropics/anthropic-sdk-go/option"
 )
 
 const (
@@ -110,8 +116,39 @@ func New(baseURLFn, apiKeyFn func() string, opts ...Option) *Discoverer {
 	for _, opt := range opts {
 		opt(d)
 	}
+	// Bound the response body size regardless of which client is used, so an
+	// unexpectedly large upstream body cannot exhaust memory.
+	// Governing: SPEC-0035 REQ "Request Body Size Limits".
+	rt := d.client.Transport
+	if rt == nil {
+		rt = http.DefaultTransport
+	}
+	d.client.Transport = &limitedTransport{rt: rt, max: maxBodyBytes}
 	return d
 }
+
+// limitedTransport caps the size of response bodies returned to the SDK.
+type limitedTransport struct {
+	rt  http.RoundTripper
+	max int64
+}
+
+func (t *limitedTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	resp, err := t.rt.RoundTrip(req)
+	if err != nil {
+		return nil, err
+	}
+	resp.Body = &limitedReadCloser{r: io.LimitReader(resp.Body, t.max), c: resp.Body}
+	return resp, nil
+}
+
+type limitedReadCloser struct {
+	r io.Reader
+	c io.Closer
+}
+
+func (l *limitedReadCloser) Read(p []byte) (int, error) { return l.r.Read(p) }
+func (l *limitedReadCloser) Close() error               { return l.c.Close() }
 
 // Available returns the current discovered models, refreshing from the upstream
 // gateway if the cache is stale. It never returns an error: when discovery is
@@ -195,70 +232,51 @@ func (d *Discoverer) snapshotLocked() Result {
 	}
 }
 
-// openAIModelList mirrors the OpenAI-style models response:
-// {"object":"list","data":[{"id":"...","object":"model",...}]}.
-type openAIModelList struct {
-	Object string `json:"object"`
-	Data   []struct {
-		ID string `json:"id"`
-	} `json:"data"`
-}
-
-// fetch performs the upstream GET, parses the body, and returns a de-duplicated,
-// sorted list of model IDs. The upstream API key is sent only in the
-// Authorization header and never logged.
+// fetch lists models from the upstream gateway via the Anthropic SDK and returns
+// a de-duplicated, sorted list of model IDs. The SDK is pointed at the configured
+// base URL with the upstream key; the key is passed only to the SDK (in the auth
+// header it sets) and is never logged. The bounded http.Client (with a body-size
+// limit on its transport) and the SDK request timeout enforce the time and size
+// bounds.
 // Governing: SPEC-0035 REQ "Upstream Model Query", REQ "Upstream Call Security and Error Handling".
 func (d *Discoverer) fetch(ctx context.Context) ([]string, error) {
 	base := strings.TrimRight(strings.TrimSpace(d.baseURLFn()), "/")
-	url := base + "/v1/models"
 
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
-	if err != nil {
-		return nil, fmt.Errorf("discover upstream models: build request: %w", err)
+	opts := []option.RequestOption{
+		option.WithBaseURL(base),
+		option.WithHTTPClient(d.client),
+		option.WithRequestTimeout(d.client.Timeout),
+		// Discovery is best-effort; don't let the SDK retry a slow/failing
+		// gateway and blow past our bound.
+		option.WithMaxRetries(0),
 	}
 	if key := strings.TrimSpace(d.apiKeyFn()); key != "" {
-		req.Header.Set("Authorization", "Bearer "+key)
+		opts = append(opts, option.WithAPIKey(key))
 	}
-	req.Header.Set("Accept", "application/json")
+	client := anthropic.NewClient(opts...)
 
-	resp, err := d.client.Do(req)
-	if err != nil {
-		// %w preserves the underlying error (timeout, connection refused) which
-		// never contains the API key.
-		log.Printf("model discovery: request to upstream gateway failed: %v", err)
-		return nil, fmt.Errorf("discover upstream models: request failed: %w", err)
+	var ids []string
+	pager := client.Models.ListAutoPaging(ctx, anthropic.ModelListParams{})
+	for pager.Next() {
+		ids = append(ids, pager.Current().ID)
 	}
-	defer func() { _ = resp.Body.Close() }()
-
-	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		log.Printf("model discovery: upstream gateway returned status=%d", resp.StatusCode)
-		return nil, fmt.Errorf("discover upstream models: unexpected status %d", resp.StatusCode)
+	if err := pager.Err(); err != nil {
+		// The SDK error wraps the HTTP status / transport error (timeout,
+		// connection refused, non-2xx) and never contains the API key value.
+		log.Printf("model discovery: upstream gateway list failed: %v", err)
+		return nil, err
 	}
 
-	body, err := io.ReadAll(io.LimitReader(resp.Body, maxBodyBytes))
-	if err != nil {
-		log.Printf("model discovery: reading upstream response failed: %v", err)
-		return nil, fmt.Errorf("discover upstream models: read body: %w", err)
-	}
-
-	var parsed openAIModelList
-	if err := json.Unmarshal(body, &parsed); err != nil {
-		log.Printf("model discovery: parsing upstream response failed: %v", err)
-		return nil, fmt.Errorf("discover upstream models: parse body: %w", err)
-	}
-
-	return dedupeSort(parsed.Data), nil
+	return dedupeSort(ids), nil
 }
 
-// dedupeSort extracts non-empty model IDs, removes duplicates, and sorts them
-// for a stable presentation order.
-func dedupeSort(data []struct {
-	ID string `json:"id"`
-}) []string {
-	seen := make(map[string]struct{}, len(data))
-	out := make([]string, 0, len(data))
-	for _, m := range data {
-		id := strings.TrimSpace(m.ID)
+// dedupeSort trims, de-duplicates, and sorts model IDs for a stable presentation
+// order.
+func dedupeSort(ids []string) []string {
+	seen := make(map[string]struct{}, len(ids))
+	out := make([]string, 0, len(ids))
+	for _, id := range ids {
+		id = strings.TrimSpace(id)
 		if id == "" {
 			continue
 		}

--- a/internal/models/discovery.go
+++ b/internal/models/discovery.go
@@ -1,0 +1,273 @@
+// Package models discovers the set of LLM models available on the upstream
+// OpenAI/Anthropic-compatible gateway (e.g. LiteLLM) that Claude Ops routes
+// through. The gateway is configured via the ANTHROPIC_BASE_URL environment
+// variable and authenticated with ANTHROPIC_API_KEY.
+//
+// Governing: SPEC-0035 (Upstream Model Auto-Discovery). The discovery SOURCE is
+// the upstream gateway's GET ${ANTHROPIC_BASE_URL}/v1/models — distinct from
+// Claude Ops' OWN served /v1/models endpoint (SPEC-0024 / ADR-0020).
+package models
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log"
+	"net/http"
+	"sort"
+	"strings"
+	"sync"
+	"time"
+)
+
+const (
+	// defaultTimeout bounds the upstream HTTP request so a slow or unreachable
+	// gateway cannot stall configuration rendering.
+	// Governing: SPEC-0035 REQ "Upstream Model Query" (bounded timeout, RECOMMENDED 5s).
+	defaultTimeout = 5 * time.Second
+
+	// defaultTTL is how long a discovered list is served from cache before a
+	// refresh is attempted on next access.
+	// Governing: SPEC-0035 REQ "Discovered Model Caching and Refresh" (RECOMMENDED 5m).
+	defaultTTL = 5 * time.Minute
+
+	// maxBodyBytes bounds how much of the upstream response we read, so an
+	// unexpectedly large body cannot exhaust memory.
+	// Governing: SPEC-0035 REQ "Request Body Size Limits".
+	maxBodyBytes = 1 << 20 // 1 MiB
+)
+
+// Result is a point-in-time snapshot of upstream model discovery, suitable for
+// returning to API clients and rendering in the config UI.
+// Governing: SPEC-0035 REQ "Available Models API Endpoint" (freshness metadata).
+type Result struct {
+	// Models is the de-duplicated, sorted list of upstream model IDs. Empty
+	// when discovery is unavailable.
+	Models []string `json:"models"`
+	// LastRefreshed is the time of the last successful upstream query, or the
+	// zero value if discovery has never succeeded.
+	LastRefreshed time.Time `json:"last_refreshed"`
+	// Available reports whether discovery is currently usable (base URL set and
+	// the most recent attempt produced a list).
+	Available bool `json:"discovery_available"`
+}
+
+// Discoverer queries the upstream gateway for available models and caches the
+// result with a TTL, collapsing concurrent refreshes via single-flight.
+//
+// The zero value is not usable; construct with New.
+type Discoverer struct {
+	// baseURLFn and apiKeyFn are resolved lazily on each refresh so that
+	// runtime changes to the environment are picked up without a restart and so
+	// the API key is never captured/stored beyond the lifetime of a request.
+	baseURLFn func() string
+	apiKeyFn  func() string
+
+	client *http.Client
+	ttl    time.Duration
+
+	mu            sync.Mutex
+	models        []string
+	lastRefreshed time.Time
+	available     bool
+	refreshing    bool       // single-flight guard
+	cond          *sync.Cond // wakes waiters when an in-flight refresh finishes
+}
+
+// Option configures a Discoverer.
+type Option func(*Discoverer)
+
+// WithTTL overrides the cache time-to-live.
+func WithTTL(ttl time.Duration) Option {
+	return func(d *Discoverer) {
+		if ttl > 0 {
+			d.ttl = ttl
+		}
+	}
+}
+
+// WithHTTPClient overrides the HTTP client (primarily for tests).
+func WithHTTPClient(c *http.Client) Option {
+	return func(d *Discoverer) {
+		if c != nil {
+			d.client = c
+		}
+	}
+}
+
+// New constructs a Discoverer. baseURLFn and apiKeyFn are called on each refresh
+// to resolve the current upstream endpoint and credential; both may return "".
+// Governing: SPEC-0035 REQ "Upstream Model Query", REQ "Graceful Degradation".
+func New(baseURLFn, apiKeyFn func() string, opts ...Option) *Discoverer {
+	d := &Discoverer{
+		baseURLFn: baseURLFn,
+		apiKeyFn:  apiKeyFn,
+		client:    &http.Client{Timeout: defaultTimeout},
+		ttl:       defaultTTL,
+	}
+	d.cond = sync.NewCond(&d.mu)
+	for _, opt := range opts {
+		opt(d)
+	}
+	return d
+}
+
+// Available returns the current discovered models, refreshing from the upstream
+// gateway if the cache is stale. It never returns an error: when discovery is
+// unavailable it returns a Result with Available=false and the most recent
+// successfully-cached list (empty if there has never been one).
+// Governing: SPEC-0035 REQ "Discovered Model Caching and Refresh", REQ "Graceful Degradation".
+func (d *Discoverer) Available(ctx context.Context) Result {
+	return d.get(ctx, false)
+}
+
+// Refresh forces an immediate upstream re-query, bypassing the TTL, and returns
+// the resulting snapshot. Concurrent refreshes collapse to a single in-flight
+// upstream call via single-flight.
+// Governing: SPEC-0035 REQ "Discovered Model Caching and Refresh" (explicit refresh),
+// REQ "Rate Limiting" (single-flight).
+func (d *Discoverer) Refresh(ctx context.Context) Result {
+	return d.get(ctx, true)
+}
+
+func (d *Discoverer) get(ctx context.Context, force bool) Result {
+	d.mu.Lock()
+
+	// No upstream configured: discovery is unavailable, never attempt a request.
+	// Governing: SPEC-0035 REQ "Graceful Degradation" (base URL unset).
+	if strings.TrimSpace(d.baseURLFn()) == "" {
+		d.available = false
+		res := d.snapshotLocked()
+		d.mu.Unlock()
+		return res
+	}
+
+	fresh := time.Since(d.lastRefreshed) < d.ttl && !d.lastRefreshed.IsZero()
+	if !force && fresh {
+		res := d.snapshotLocked()
+		d.mu.Unlock()
+		return res
+	}
+
+	// Single-flight: if a refresh is already running, wait for it rather than
+	// issuing a second upstream request.
+	if d.refreshing {
+		for d.refreshing {
+			d.cond.Wait()
+		}
+		res := d.snapshotLocked()
+		d.mu.Unlock()
+		return res
+	}
+
+	d.refreshing = true
+	d.mu.Unlock()
+
+	models, err := d.fetch(ctx)
+
+	d.mu.Lock()
+	if err != nil {
+		// Discovery failed for this attempt: keep any prior list but mark
+		// unavailable. Error already logged in fetch with non-secret context.
+		// Governing: SPEC-0035 REQ "Graceful Degradation", REQ "Upstream Call Security and Error Handling".
+		d.available = false
+	} else {
+		d.models = models
+		d.lastRefreshed = time.Now()
+		d.available = true
+	}
+	d.refreshing = false
+	d.cond.Broadcast()
+	res := d.snapshotLocked()
+	d.mu.Unlock()
+	return res
+}
+
+// snapshotLocked returns a copy of the current cache state. Caller must hold d.mu.
+func (d *Discoverer) snapshotLocked() Result {
+	out := make([]string, len(d.models))
+	copy(out, d.models)
+	return Result{
+		Models:        out,
+		LastRefreshed: d.lastRefreshed,
+		Available:     d.available,
+	}
+}
+
+// openAIModelList mirrors the OpenAI-style models response:
+// {"object":"list","data":[{"id":"...","object":"model",...}]}.
+type openAIModelList struct {
+	Object string `json:"object"`
+	Data   []struct {
+		ID string `json:"id"`
+	} `json:"data"`
+}
+
+// fetch performs the upstream GET, parses the body, and returns a de-duplicated,
+// sorted list of model IDs. The upstream API key is sent only in the
+// Authorization header and never logged.
+// Governing: SPEC-0035 REQ "Upstream Model Query", REQ "Upstream Call Security and Error Handling".
+func (d *Discoverer) fetch(ctx context.Context) ([]string, error) {
+	base := strings.TrimRight(strings.TrimSpace(d.baseURLFn()), "/")
+	url := base + "/v1/models"
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return nil, fmt.Errorf("discover upstream models: build request: %w", err)
+	}
+	if key := strings.TrimSpace(d.apiKeyFn()); key != "" {
+		req.Header.Set("Authorization", "Bearer "+key)
+	}
+	req.Header.Set("Accept", "application/json")
+
+	resp, err := d.client.Do(req)
+	if err != nil {
+		// %w preserves the underlying error (timeout, connection refused) which
+		// never contains the API key.
+		log.Printf("model discovery: request to upstream gateway failed: %v", err)
+		return nil, fmt.Errorf("discover upstream models: request failed: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		log.Printf("model discovery: upstream gateway returned status=%d", resp.StatusCode)
+		return nil, fmt.Errorf("discover upstream models: unexpected status %d", resp.StatusCode)
+	}
+
+	body, err := io.ReadAll(io.LimitReader(resp.Body, maxBodyBytes))
+	if err != nil {
+		log.Printf("model discovery: reading upstream response failed: %v", err)
+		return nil, fmt.Errorf("discover upstream models: read body: %w", err)
+	}
+
+	var parsed openAIModelList
+	if err := json.Unmarshal(body, &parsed); err != nil {
+		log.Printf("model discovery: parsing upstream response failed: %v", err)
+		return nil, fmt.Errorf("discover upstream models: parse body: %w", err)
+	}
+
+	return dedupeSort(parsed.Data), nil
+}
+
+// dedupeSort extracts non-empty model IDs, removes duplicates, and sorts them
+// for a stable presentation order.
+func dedupeSort(data []struct {
+	ID string `json:"id"`
+}) []string {
+	seen := make(map[string]struct{}, len(data))
+	out := make([]string, 0, len(data))
+	for _, m := range data {
+		id := strings.TrimSpace(m.ID)
+		if id == "" {
+			continue
+		}
+		if _, dup := seen[id]; dup {
+			continue
+		}
+		seen[id] = struct{}{}
+		out = append(out, id)
+	}
+	sort.Strings(out)
+	return out
+}

--- a/internal/models/discovery_test.go
+++ b/internal/models/discovery_test.go
@@ -11,6 +11,19 @@ import (
 	"time"
 )
 
+// modelsJSON builds an Anthropic-style models list response body.
+func modelsJSON(ids ...string) string {
+	body := `{"data":[`
+	for i, id := range ids {
+		if i > 0 {
+			body += ","
+		}
+		body += `{"id":"` + id + `","type":"model"}`
+	}
+	body += `],"has_more":false}`
+	return body
+}
+
 // Governing: SPEC-0035 REQ "Upstream Model Query" — fetch, parse, dedupe, sort.
 func TestAvailable_ParsesAndSorts(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -18,7 +31,7 @@ func TestAvailable_ParsesAndSorts(t *testing.T) {
 			t.Errorf("expected /v1/models, got %s", r.URL.Path)
 		}
 		w.Header().Set("Content-Type", "application/json")
-		_, _ = w.Write([]byte(`{"object":"list","data":[{"id":"gemini-2.5-pro"},{"id":"deepseek-chat"},{"id":"claude-opus-4-8"},{"id":"deepseek-chat"}]}`))
+		_, _ = w.Write([]byte(modelsJSON("gemini-2.5-pro", "deepseek-chat", "claude-opus-4-8", "deepseek-chat")))
 	}))
 	defer srv.Close()
 
@@ -47,7 +60,8 @@ func TestAvailable_TrailingSlash(t *testing.T) {
 	var gotPath string
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		gotPath = r.URL.Path
-		_, _ = w.Write([]byte(`{"object":"list","data":[]}`))
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(modelsJSON()))
 	}))
 	defer srv.Close()
 
@@ -58,19 +72,22 @@ func TestAvailable_TrailingSlash(t *testing.T) {
 	}
 }
 
-// Governing: SPEC-0035 REQ "Upstream Model Query" — Bearer auth header.
-func TestAvailable_SendsBearer(t *testing.T) {
-	var gotAuth string
+// Governing: SPEC-0035 REQ "Upstream Model Query" — the upstream credential is
+// sent to the gateway. The Anthropic SDK authenticates via the x-api-key header
+// (LiteLLM accepts this for Anthropic-compatible routing).
+func TestAvailable_SendsAPIKey(t *testing.T) {
+	var gotKey string
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		gotAuth = r.Header.Get("Authorization")
-		_, _ = w.Write([]byte(`{"object":"list","data":[{"id":"m"}]}`))
+		gotKey = r.Header.Get("x-api-key")
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(modelsJSON("m")))
 	}))
 	defer srv.Close()
 
 	d := New(func() string { return srv.URL }, func() string { return "secret-key" })
 	d.Available(context.Background())
-	if gotAuth != "Bearer secret-key" {
-		t.Fatalf("expected Bearer auth header, got %q", gotAuth)
+	if gotKey != "secret-key" {
+		t.Fatalf("expected x-api-key header to carry the upstream key, got %q", gotKey)
 	}
 }
 
@@ -128,7 +145,8 @@ func TestAvailable_CacheHit(t *testing.T) {
 	var hits int32
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		atomic.AddInt32(&hits, 1)
-		_, _ = w.Write([]byte(`{"object":"list","data":[{"id":"m"}]}`))
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(modelsJSON("m")))
 	}))
 	defer srv.Close()
 
@@ -145,7 +163,8 @@ func TestRefresh_BypassesTTL(t *testing.T) {
 	var hits int32
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		atomic.AddInt32(&hits, 1)
-		_, _ = w.Write([]byte(`{"object":"list","data":[{"id":"m"}]}`))
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(modelsJSON("m")))
 	}))
 	defer srv.Close()
 
@@ -164,7 +183,8 @@ func TestRefresh_SingleFlight(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		atomic.AddInt32(&hits, 1)
 		<-release // hold the request open so concurrent callers pile up
-		_, _ = w.Write([]byte(`{"object":"list","data":[{"id":"m"}]}`))
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(modelsJSON("m")))
 	}))
 	defer srv.Close()
 

--- a/internal/models/discovery_test.go
+++ b/internal/models/discovery_test.go
@@ -1,0 +1,193 @@
+package models
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// Governing: SPEC-0035 REQ "Upstream Model Query" — fetch, parse, dedupe, sort.
+func TestAvailable_ParsesAndSorts(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v1/models" {
+			t.Errorf("expected /v1/models, got %s", r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"object":"list","data":[{"id":"gemini-2.5-pro"},{"id":"deepseek-chat"},{"id":"claude-opus-4-8"},{"id":"deepseek-chat"}]}`))
+	}))
+	defer srv.Close()
+
+	d := New(func() string { return srv.URL }, func() string { return "" })
+	res := d.Available(context.Background())
+
+	if !res.Available {
+		t.Fatalf("expected discovery available")
+	}
+	want := []string{"claude-opus-4-8", "deepseek-chat", "gemini-2.5-pro"}
+	if len(res.Models) != len(want) {
+		t.Fatalf("got %v, want %v", res.Models, want)
+	}
+	for i := range want {
+		if res.Models[i] != want[i] {
+			t.Fatalf("got %v, want %v (deduped+sorted)", res.Models, want)
+		}
+	}
+	if res.LastRefreshed.IsZero() {
+		t.Errorf("expected LastRefreshed to be set")
+	}
+}
+
+// Governing: SPEC-0035 REQ "Upstream Model Query" — trailing slash on base URL.
+func TestAvailable_TrailingSlash(t *testing.T) {
+	var gotPath string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		_, _ = w.Write([]byte(`{"object":"list","data":[]}`))
+	}))
+	defer srv.Close()
+
+	d := New(func() string { return srv.URL + "/" }, func() string { return "" })
+	d.Available(context.Background())
+	if gotPath != "/v1/models" {
+		t.Fatalf("expected no doubled slash, got path %q", gotPath)
+	}
+}
+
+// Governing: SPEC-0035 REQ "Upstream Model Query" — Bearer auth header.
+func TestAvailable_SendsBearer(t *testing.T) {
+	var gotAuth string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotAuth = r.Header.Get("Authorization")
+		_, _ = w.Write([]byte(`{"object":"list","data":[{"id":"m"}]}`))
+	}))
+	defer srv.Close()
+
+	d := New(func() string { return srv.URL }, func() string { return "secret-key" })
+	d.Available(context.Background())
+	if gotAuth != "Bearer secret-key" {
+		t.Fatalf("expected Bearer auth header, got %q", gotAuth)
+	}
+}
+
+// Governing: SPEC-0035 REQ "Graceful Degradation" — base URL unset, no request attempted.
+func TestAvailable_BaseURLUnset(t *testing.T) {
+	called := false
+	d := New(func() string { return "" }, func() string { return "" },
+		WithHTTPClient(&http.Client{Transport: roundTripFunc(func(*http.Request) (*http.Response, error) {
+			called = true
+			return nil, fmt.Errorf("should not be called")
+		})}))
+
+	res := d.Available(context.Background())
+	if called {
+		t.Fatal("expected no upstream request when base URL unset")
+	}
+	if res.Available {
+		t.Fatal("expected discovery unavailable when base URL unset")
+	}
+	if len(res.Models) != 0 {
+		t.Fatalf("expected empty model list, got %v", res.Models)
+	}
+}
+
+// Governing: SPEC-0035 REQ "Graceful Degradation" — non-2xx upstream response.
+func TestAvailable_Non2xx(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusServiceUnavailable)
+	}))
+	defer srv.Close()
+
+	d := New(func() string { return srv.URL }, func() string { return "" })
+	res := d.Available(context.Background())
+	if res.Available {
+		t.Fatal("expected discovery unavailable on non-2xx")
+	}
+}
+
+// Governing: SPEC-0035 REQ "Graceful Degradation" — unparseable body.
+func TestAvailable_UnparseableBody(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`not json`))
+	}))
+	defer srv.Close()
+
+	d := New(func() string { return srv.URL }, func() string { return "" })
+	res := d.Available(context.Background())
+	if res.Available {
+		t.Fatal("expected discovery unavailable on parse error")
+	}
+}
+
+// Governing: SPEC-0035 REQ "Discovered Model Caching and Refresh" — cache hit within TTL.
+func TestAvailable_CacheHit(t *testing.T) {
+	var hits int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&hits, 1)
+		_, _ = w.Write([]byte(`{"object":"list","data":[{"id":"m"}]}`))
+	}))
+	defer srv.Close()
+
+	d := New(func() string { return srv.URL }, func() string { return "" }, WithTTL(time.Hour))
+	d.Available(context.Background())
+	d.Available(context.Background())
+	if got := atomic.LoadInt32(&hits); got != 1 {
+		t.Fatalf("expected 1 upstream call within TTL, got %d", got)
+	}
+}
+
+// Governing: SPEC-0035 REQ "Discovered Model Caching and Refresh" — explicit refresh bypasses TTL.
+func TestRefresh_BypassesTTL(t *testing.T) {
+	var hits int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&hits, 1)
+		_, _ = w.Write([]byte(`{"object":"list","data":[{"id":"m"}]}`))
+	}))
+	defer srv.Close()
+
+	d := New(func() string { return srv.URL }, func() string { return "" }, WithTTL(time.Hour))
+	d.Available(context.Background())
+	d.Refresh(context.Background())
+	if got := atomic.LoadInt32(&hits); got != 2 {
+		t.Fatalf("expected refresh to re-query (2 calls), got %d", got)
+	}
+}
+
+// Governing: SPEC-0035 REQ "Rate Limiting" — concurrent refreshes collapse to one in-flight call.
+func TestRefresh_SingleFlight(t *testing.T) {
+	var hits int32
+	release := make(chan struct{})
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&hits, 1)
+		<-release // hold the request open so concurrent callers pile up
+		_, _ = w.Write([]byte(`{"object":"list","data":[{"id":"m"}]}`))
+	}))
+	defer srv.Close()
+
+	d := New(func() string { return srv.URL }, func() string { return "" })
+
+	var wg sync.WaitGroup
+	for i := 0; i < 5; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			d.Refresh(context.Background())
+		}()
+	}
+	// Give the goroutines time to converge on the single-flight guard.
+	time.Sleep(50 * time.Millisecond)
+	close(release)
+	wg.Wait()
+
+	if got := atomic.LoadInt32(&hits); got != 1 {
+		t.Fatalf("expected single in-flight upstream call, got %d", got)
+	}
+}
+
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripFunc) RoundTrip(r *http.Request) (*http.Response, error) { return f(r) }

--- a/internal/web/handlers.go
+++ b/internal/web/handlers.go
@@ -658,34 +658,7 @@ func (s *Server) handleMemoryDelete(w http.ResponseWriter, r *http.Request) {
 // handleConfigGet renders the configuration form.
 // Governing: SPEC-0008 REQ-10 — configuration page: runtime parameter display and modification.
 func (s *Server) handleConfigGet(w http.ResponseWriter, r *http.Request) {
-	data := struct {
-		Interval              int
-		Tier1Model            string
-		Tier2Model            string
-		Tier3Model            string
-		DryRun                bool
-		Saved                 bool
-		StateDir              string
-		ResultsDir            string
-		ReposDir              string
-		MaxTier               int
-		BrowserAllowedOrigins string
-		ChatAPIKey            string
-	}{
-		Interval:              s.cfg.Interval,
-		Tier1Model:            s.cfg.Tier1Model,
-		Tier2Model:            s.cfg.Tier2Model,
-		Tier3Model:            s.cfg.Tier3Model,
-		DryRun:                s.cfg.DryRun,
-		StateDir:              s.cfg.StateDir,
-		ResultsDir:            s.cfg.ResultsDir,
-		ReposDir:              s.cfg.ReposDir,
-		MaxTier:               s.cfg.MaxTier,
-		BrowserAllowedOrigins: s.cfg.BrowserAllowedOrigins,
-		ChatAPIKey:            os.Getenv("CLAUDEOPS_CHAT_API_KEY"),
-	}
-
-	s.render(w, r, "config.html", data)
+	s.render(w, r, "config.html", s.buildConfigPageData(r, false))
 }
 
 // classifyPromptTier calls the Anthropic Messages API with claude-haiku to
@@ -817,35 +790,7 @@ func (s *Server) handleConfigPost(w http.ResponseWriter, r *http.Request) {
 	log.Printf("config updated: interval=%d tier1=%s tier2=%s tier3=%s dry_run=%v",
 		s.cfg.Interval, s.cfg.Tier1Model, s.cfg.Tier2Model, s.cfg.Tier3Model, s.cfg.DryRun)
 
-	data := struct {
-		Interval              int
-		Tier1Model            string
-		Tier2Model            string
-		Tier3Model            string
-		DryRun                bool
-		Saved                 bool
-		StateDir              string
-		ResultsDir            string
-		ReposDir              string
-		MaxTier               int
-		BrowserAllowedOrigins string
-		ChatAPIKey            string
-	}{
-		Interval:              s.cfg.Interval,
-		Tier1Model:            s.cfg.Tier1Model,
-		Tier2Model:            s.cfg.Tier2Model,
-		Tier3Model:            s.cfg.Tier3Model,
-		DryRun:                s.cfg.DryRun,
-		Saved:                 true,
-		StateDir:              s.cfg.StateDir,
-		ResultsDir:            s.cfg.ResultsDir,
-		ReposDir:              s.cfg.ReposDir,
-		MaxTier:               s.cfg.MaxTier,
-		BrowserAllowedOrigins: s.cfg.BrowserAllowedOrigins,
-		ChatAPIKey:            os.Getenv("CLAUDEOPS_CHAT_API_KEY"),
-	}
-
-	s.render(w, r, "config.html", data)
+	s.render(w, r, "config.html", s.buildConfigPageData(r, true))
 }
 
 // handleStopSession stops the currently running session.

--- a/internal/web/models_handler.go
+++ b/internal/web/models_handler.go
@@ -1,0 +1,153 @@
+package web
+
+import (
+	"net/http"
+	"os"
+
+	"github.com/joestump/claude-ops/internal/models"
+)
+
+// Governing: SPEC-0035 REQ "Upstream Model Query" — the upstream gateway and its
+// credential are configured via the ANTHROPIC_BASE_URL / ANTHROPIC_API_KEY
+// environment variables (the same ones the Claude Code CLI subprocess uses).
+// Resolved lazily so runtime changes are honored and the key is never stored.
+func upstreamBaseURL() string { return os.Getenv("ANTHROPIC_BASE_URL") }
+func upstreamAPIKey() string  { return os.Getenv("ANTHROPIC_API_KEY") }
+
+// registerModelRoutes wires the upstream-model-discovery endpoints onto the
+// server mux. It is called from New after registerRoutes so the route table in
+// server.go is not modified.
+// Governing: SPEC-0035 REQ "Available Models API Endpoint".
+func (s *Server) registerModelRoutes() {
+	s.mux.HandleFunc("GET /api/v1/models/available", s.handleAPIModelsAvailable)
+	s.mux.HandleFunc("POST /api/v1/models/available/refresh", s.handleAPIModelsRefresh)
+	// HTMX-driven refresh of the config-page tier model controls.
+	// Governing: SPEC-0035 REQ "Configuration UI Model Selection".
+	s.mux.HandleFunc("POST /config/models/refresh", s.handleConfigModelsRefresh)
+}
+
+// APIAvailableModelsResponse is the JSON payload for GET /api/v1/models/available.
+// It carries the discovered model IDs plus cache-freshness metadata so clients
+// can present a selectable list and decide how to handle a stale/unavailable
+// upstream.
+// Governing: SPEC-0035 REQ "Available Models API Endpoint".
+type APIAvailableModelsResponse struct {
+	Models             []string `json:"models"`
+	LastRefreshed      *string  `json:"last_refreshed"`
+	DiscoveryAvailable bool     `json:"discovery_available"`
+}
+
+// handleAPIModelsAvailable returns the discovered upstream models. It refreshes
+// from the gateway when the cache is stale, or immediately when ?refresh=true.
+// When discovery is unavailable it returns 200 with an empty list and
+// discovery_available=false rather than an error status.
+// Governing: SPEC-0035 REQ "Available Models API Endpoint", REQ "Graceful Degradation".
+func (s *Server) handleAPIModelsAvailable(w http.ResponseWriter, r *http.Request) {
+	var res models.Result
+	if r.URL.Query().Get("refresh") == "true" {
+		res = s.discoverer.Refresh(r.Context())
+	} else {
+		res = s.discoverer.Available(r.Context())
+	}
+	writeJSON(w, http.StatusOK, toAPIAvailableModels(res))
+}
+
+// handleAPIModelsRefresh forces an upstream re-query and returns the refreshed
+// list. Concurrent refreshes collapse to a single in-flight upstream call.
+// Governing: SPEC-0035 REQ "Available Models API Endpoint" (explicit refresh),
+// REQ "Rate Limiting" (single-flight).
+func (s *Server) handleAPIModelsRefresh(w http.ResponseWriter, r *http.Request) {
+	res := s.discoverer.Refresh(r.Context())
+	writeJSON(w, http.StatusOK, toAPIAvailableModels(res))
+}
+
+// configPageData is the template payload for config.html. It carries the
+// existing runtime config plus the discovered upstream models (SPEC-0035) so the
+// tier fields can render as a dropdown, falling back to free-text when discovery
+// is unavailable.
+// Governing: SPEC-0008 REQ-10 (config page), SPEC-0035 REQ "Configuration UI Model Selection".
+type configPageData struct {
+	Interval              int
+	Tier1Model            string
+	Tier2Model            string
+	Tier3Model            string
+	DryRun                bool
+	Saved                 bool
+	StateDir              string
+	ResultsDir            string
+	ReposDir              string
+	MaxTier               int
+	BrowserAllowedOrigins string
+	ChatAPIKey            string
+	// SPEC-0035 fields:
+	AvailableModels    []string
+	DiscoveryAvailable bool
+}
+
+// buildConfigPageData assembles the config-page template payload, including the
+// discovered upstream model list. Discovery failure never blocks rendering: on
+// an unavailable upstream, AvailableModels is empty and DiscoveryAvailable is
+// false, and the template falls back to free-text inputs.
+// Governing: SPEC-0035 REQ "Configuration UI Model Selection", REQ "Graceful Degradation".
+func (s *Server) buildConfigPageData(r *http.Request, saved bool) configPageData {
+	disc := s.discoverer.Available(r.Context())
+	return configPageData{
+		Interval:              s.cfg.Interval,
+		Tier1Model:            s.cfg.Tier1Model,
+		Tier2Model:            s.cfg.Tier2Model,
+		Tier3Model:            s.cfg.Tier3Model,
+		DryRun:                s.cfg.DryRun,
+		Saved:                 saved,
+		StateDir:              s.cfg.StateDir,
+		ResultsDir:            s.cfg.ResultsDir,
+		ReposDir:              s.cfg.ReposDir,
+		MaxTier:               s.cfg.MaxTier,
+		BrowserAllowedOrigins: s.cfg.BrowserAllowedOrigins,
+		ChatAPIKey:            os.Getenv("CLAUDEOPS_CHAT_API_KEY"),
+		AvailableModels:       disc.Models,
+		DiscoveryAvailable:    disc.Available,
+	}
+}
+
+// handleConfigModelsRefresh forces an upstream re-query and re-renders just the
+// per-tier model controls (the "modelFields" template block) for an HTMX swap.
+// It preserves the operator's current (possibly unsaved) tier selections from
+// the submitted form so a refresh does not discard in-progress edits.
+// Governing: SPEC-0035 REQ "Configuration UI Model Selection".
+func (s *Server) handleConfigModelsRefresh(w http.ResponseWriter, r *http.Request) {
+	_ = r.ParseForm()
+	disc := s.discoverer.Refresh(r.Context())
+	data := configPageData{
+		Tier1Model:         firstNonEmpty(r.FormValue("tier1_model"), s.cfg.Tier1Model),
+		Tier2Model:         firstNonEmpty(r.FormValue("tier2_model"), s.cfg.Tier2Model),
+		Tier3Model:         firstNonEmpty(r.FormValue("tier3_model"), s.cfg.Tier3Model),
+		AvailableModels:    disc.Models,
+		DiscoveryAvailable: disc.Available,
+	}
+	w.Header().Set("Content-Type", "text/html; charset=utf-8")
+	if err := s.tmpl.ExecuteTemplate(w, "modelFields", data); err != nil {
+		http.Error(w, "template error", http.StatusInternalServerError)
+	}
+}
+
+func firstNonEmpty(a, b string) string {
+	if a != "" {
+		return a
+	}
+	return b
+}
+
+func toAPIAvailableModels(res models.Result) APIAvailableModelsResponse {
+	out := APIAvailableModelsResponse{
+		Models:             res.Models,
+		DiscoveryAvailable: res.Available,
+	}
+	if out.Models == nil {
+		out.Models = []string{}
+	}
+	if !res.LastRefreshed.IsZero() {
+		ts := res.LastRefreshed.UTC().Format("2006-01-02T15:04:05Z07:00")
+		out.LastRefreshed = &ts
+	}
+	return out
+}

--- a/internal/web/models_handler_test.go
+++ b/internal/web/models_handler_test.go
@@ -1,0 +1,203 @@
+package web
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+
+	"github.com/joestump/claude-ops/internal/models"
+)
+
+// stubUpstream returns an httptest server speaking the OpenAI /v1/models shape,
+// plus a Discoverer pointed at it.
+func stubUpstream(t *testing.T, ids ...string) (*httptest.Server, *models.Discoverer) {
+	t.Helper()
+	body := `{"object":"list","data":[`
+	for i, id := range ids {
+		if i > 0 {
+			body += ","
+		}
+		body += `{"id":"` + id + `"}`
+	}
+	body += `]}`
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(body))
+	}))
+	t.Cleanup(srv.Close)
+	d := models.New(func() string { return srv.URL }, func() string { return "" })
+	return srv, d
+}
+
+// Governing: SPEC-0035 REQ "Available Models API Endpoint" — list with metadata.
+func TestAPIModelsAvailable_List(t *testing.T) {
+	e := newTestEnv(t)
+	_, d := stubUpstream(t, "gemini-2.5-pro", "deepseek-chat")
+	e.srv.discoverer = d
+
+	req := httptest.NewRequest("GET", "/api/v1/models/available", nil)
+	w := httptest.NewRecorder()
+	e.srv.mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+	if ct := w.Header().Get("Content-Type"); !strings.Contains(ct, "application/json") {
+		t.Fatalf("expected application/json, got %q", ct)
+	}
+	var resp APIAvailableModelsResponse
+	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if !resp.DiscoveryAvailable {
+		t.Fatalf("expected discovery_available=true")
+	}
+	if len(resp.Models) != 2 || resp.Models[0] != "deepseek-chat" || resp.Models[1] != "gemini-2.5-pro" {
+		t.Fatalf("expected sorted models, got %v", resp.Models)
+	}
+	if resp.LastRefreshed == nil {
+		t.Fatalf("expected last_refreshed to be set")
+	}
+}
+
+// Governing: SPEC-0035 REQ "Graceful Degradation" — unavailable returns 200 + empty + flag.
+func TestAPIModelsAvailable_Unavailable(t *testing.T) {
+	e := newTestEnv(t)
+	// Discoverer with no base URL → unavailable, no request attempted.
+	e.srv.discoverer = models.New(func() string { return "" }, func() string { return "" })
+
+	req := httptest.NewRequest("GET", "/api/v1/models/available", nil)
+	w := httptest.NewRecorder()
+	e.srv.mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200 even when unavailable, got %d", w.Code)
+	}
+	var resp APIAvailableModelsResponse
+	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if resp.DiscoveryAvailable {
+		t.Fatalf("expected discovery_available=false")
+	}
+	if len(resp.Models) != 0 {
+		t.Fatalf("expected empty models, got %v", resp.Models)
+	}
+	if resp.Models == nil {
+		t.Fatalf("expected non-nil (JSON []) models slice")
+	}
+}
+
+// Governing: SPEC-0035 REQ "Available Models API Endpoint" — explicit refresh endpoint.
+func TestAPIModelsRefresh(t *testing.T) {
+	e := newTestEnv(t)
+	_, d := stubUpstream(t, "m1")
+	e.srv.discoverer = d
+
+	req := httptest.NewRequest("POST", "/api/v1/models/available/refresh", nil)
+	w := httptest.NewRecorder()
+	e.srv.mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+	var resp APIAvailableModelsResponse
+	_ = json.NewDecoder(w.Body).Decode(&resp)
+	if !resp.DiscoveryAvailable || len(resp.Models) != 1 {
+		t.Fatalf("expected refreshed list, got %+v", resp)
+	}
+}
+
+// Governing: SPEC-0035 REQ "Configuration UI Model Selection" — dropdown populated.
+func TestConfigPage_DropdownPopulated(t *testing.T) {
+	e := newTestEnv(t) // cfg.Tier1Model="haiku", Tier2="sonnet", Tier3="opus"
+	_, d := stubUpstream(t, "gemini-2.5-pro", "deepseek-chat")
+	e.srv.discoverer = d
+
+	req := httptest.NewRequest("GET", "/config", nil)
+	w := httptest.NewRecorder()
+	e.srv.mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+	html := w.Body.String()
+	if !strings.Contains(html, `<select id="tier1_model"`) {
+		t.Fatalf("expected a select for tier1_model when discovery available")
+	}
+	for _, id := range []string{"gemini-2.5-pro", "deepseek-chat"} {
+		if !strings.Contains(html, `value="`+id+`"`) {
+			t.Fatalf("expected discovered model %q as an option", id)
+		}
+	}
+}
+
+// Governing: SPEC-0035 REQ "Configuration UI Model Selection" — current non-discovered value preserved.
+func TestConfigPage_PreservesCurrentValue(t *testing.T) {
+	e := newTestEnv(t) // Tier1Model="haiku" (not in discovered list below)
+	_, d := stubUpstream(t, "gemini-2.5-pro")
+	e.srv.discoverer = d
+
+	req := httptest.NewRequest("GET", "/config", nil)
+	w := httptest.NewRecorder()
+	e.srv.mux.ServeHTTP(w, req)
+
+	html := w.Body.String()
+	// The current value "haiku" must appear as a selected option even though it
+	// is not among the discovered models.
+	if !strings.Contains(html, `<option value="haiku" selected>haiku</option>`) {
+		t.Fatalf("expected current non-discovered tier1 value 'haiku' preserved as selected option")
+	}
+}
+
+// Governing: SPEC-0035 REQ "Graceful Degradation" — free-text fallback when unavailable.
+func TestConfigPage_FreeTextFallback(t *testing.T) {
+	e := newTestEnv(t)
+	e.srv.discoverer = models.New(func() string { return "" }, func() string { return "" })
+
+	req := httptest.NewRequest("GET", "/config", nil)
+	w := httptest.NewRecorder()
+	e.srv.mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected config page to render when discovery unavailable, got %d", w.Code)
+	}
+	html := w.Body.String()
+	if !strings.Contains(html, `<input type="text" id="tier1_model"`) {
+		t.Fatalf("expected free-text input fallback for tier1_model when discovery unavailable")
+	}
+	if !strings.Contains(html, `value="haiku"`) {
+		t.Fatalf("expected current tier1 value preserved in free-text fallback")
+	}
+}
+
+// Governing: SPEC-0035 REQ "Configuration UI Model Selection" — HTMX refresh swap.
+func TestConfigModelsRefresh_Swap(t *testing.T) {
+	e := newTestEnv(t)
+	_, d := stubUpstream(t, "new-model-x")
+	e.srv.discoverer = d
+
+	form := url.Values{}
+	form.Set("tier1_model", "keep-this") // an unsaved selection that must survive refresh
+	req := httptest.NewRequest("POST", "/config/models/refresh", strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	w := httptest.NewRecorder()
+	e.srv.mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+	html := w.Body.String()
+	if !strings.Contains(html, `id="model-fields"`) {
+		t.Fatalf("expected the model-fields swap target in the response")
+	}
+	if !strings.Contains(html, `value="new-model-x"`) {
+		t.Fatalf("expected refreshed model option in swap, got: %s", html)
+	}
+	// The submitted (unsaved) tier1 value must be preserved across refresh.
+	if !strings.Contains(html, `value="keep-this" selected`) {
+		t.Fatalf("expected unsaved tier1 selection 'keep-this' preserved across refresh")
+	}
+}

--- a/internal/web/models_handler_test.go
+++ b/internal/web/models_handler_test.go
@@ -11,19 +11,20 @@ import (
 	"github.com/joestump/claude-ops/internal/models"
 )
 
-// stubUpstream returns an httptest server speaking the OpenAI /v1/models shape,
-// plus a Discoverer pointed at it.
+// stubUpstream returns an httptest server speaking the Anthropic models-list
+// shape (the SDK requires application/json), plus a Discoverer pointed at it.
 func stubUpstream(t *testing.T, ids ...string) (*httptest.Server, *models.Discoverer) {
 	t.Helper()
-	body := `{"object":"list","data":[`
+	body := `{"data":[`
 	for i, id := range ids {
 		if i > 0 {
 			body += ","
 		}
-		body += `{"id":"` + id + `"}`
+		body += `{"id":"` + id + `","type":"model"}`
 	}
-	body += `]}`
+	body += `],"has_more":false}`
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
 		_, _ = w.Write([]byte(body))
 	}))
 	t.Cleanup(srv.Close)

--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -16,6 +16,7 @@ import (
 	"github.com/joestump/claude-ops/api"
 	"github.com/joestump/claude-ops/internal/config"
 	"github.com/joestump/claude-ops/internal/db"
+	"github.com/joestump/claude-ops/internal/models"
 	"github.com/yuin/goldmark"
 	"github.com/yuin/goldmark/extension"
 )
@@ -74,6 +75,8 @@ type Server struct {
 	mux    *http.ServeMux
 	tmpl   *template.Template
 	server *http.Server
+	// Governing: SPEC-0035 — discovers models from the upstream gateway (ANTHROPIC_BASE_URL).
+	discoverer *models.Discoverer
 }
 
 // New creates a new web server. Pass nil for hub if SSE streaming is not yet available.
@@ -90,8 +93,14 @@ func New(cfg *config.Config, hub SSEHub, database *db.DB, mgr SessionTrigger, op
 		opt(s)
 	}
 
+	// Governing: SPEC-0035 REQ "Upstream Model Query", REQ "Graceful Degradation" —
+	// resolve the upstream endpoint/credential lazily from the environment so
+	// changes are picked up without a restart and the key is never stored.
+	s.discoverer = models.New(upstreamBaseURL, upstreamAPIKey)
+
 	s.parseTemplates()
 	s.registerRoutes()
+	s.registerModelRoutes()
 
 	s.server = &http.Server{
 		Addr:         fmt.Sprintf(":%d", cfg.DashboardPort),
@@ -196,6 +205,16 @@ func (s *Server) parseTemplates() {
 		},
 		"sub": func(a, b int) int {
 			return a - b
+		},
+		// Governing: SPEC-0035 REQ "Configuration UI Model Selection" — used to
+		// decide whether a current tier value is among the discovered models.
+		"contains": func(list []string, v string) bool {
+			for _, item := range list {
+				if item == v {
+					return true
+				}
+			}
+			return false
 		},
 		"intVal": func(p *int) int {
 			if p == nil {

--- a/internal/web/templates/config.html
+++ b/internal/web/templates/config.html
@@ -22,42 +22,24 @@
                 <p class="text-xs text-muted mt-1">How often the agent runs a health check cycle. Minimum 60 seconds.</p>
             </div>
 
-            {{/* Models */}}
+            {{/* Models — Governing: SPEC-0035 REQ "Configuration UI Model Selection" */}}
             <div>
-                <div class="text-xs text-muted uppercase tracking-wider mb-2">Escalation Models</div>
-                <p class="text-xs text-muted mb-3">Each tier uses a different model. Tier 1 observes, Tier 2 investigates and applies safe fixes, Tier 3 performs full remediation.</p>
-                <div class="grid grid-cols-1 md:grid-cols-3 gap-4">
-                    <div>
-                        <label for="tier1_model" class="block text-xs text-muted mb-1">
-                            Tier 1 &mdash; Observe
-                        </label>
-                        <select id="tier1_model" name="tier1_model" class="input-field w-full">
-                            <option value="haiku" {{if eq .Tier1Model "haiku"}}selected{{end}}>haiku</option>
-                            <option value="sonnet" {{if eq .Tier1Model "sonnet"}}selected{{end}}>sonnet</option>
-                            <option value="opus" {{if eq .Tier1Model "opus"}}selected{{end}}>opus</option>
-                        </select>
-                    </div>
-                    <div>
-                        <label for="tier2_model" class="block text-xs text-muted mb-1">
-                            Tier 2 &mdash; Investigate
-                        </label>
-                        <select id="tier2_model" name="tier2_model" class="input-field w-full">
-                            <option value="haiku" {{if eq .Tier2Model "haiku"}}selected{{end}}>haiku</option>
-                            <option value="sonnet" {{if eq .Tier2Model "sonnet"}}selected{{end}}>sonnet</option>
-                            <option value="opus" {{if eq .Tier2Model "opus"}}selected{{end}}>opus</option>
-                        </select>
-                    </div>
-                    <div>
-                        <label for="tier3_model" class="block text-xs text-muted mb-1">
-                            Tier 3 &mdash; Remediate
-                        </label>
-                        <select id="tier3_model" name="tier3_model" class="input-field w-full">
-                            <option value="haiku" {{if eq .Tier3Model "haiku"}}selected{{end}}>haiku</option>
-                            <option value="sonnet" {{if eq .Tier3Model "sonnet"}}selected{{end}}>sonnet</option>
-                            <option value="opus" {{if eq .Tier3Model "opus"}}selected{{end}}>opus</option>
-                        </select>
-                    </div>
+                <div class="flex items-center justify-between mb-2">
+                    <div class="text-xs text-muted uppercase tracking-wider">Escalation Models</div>
+                    {{/* Refresh control re-queries the upstream gateway and swaps just this block. */}}
+                    <button type="button"
+                            class="text-accent hover:text-charcoal cursor-pointer text-xs leading-none"
+                            aria-label="Refresh available models"
+                            title="Refresh available models"
+                            hx-post="/config/models/refresh"
+                            hx-target="#model-fields"
+                            hx-swap="outerHTML"
+                            hx-include="closest form">
+                        <span style="font-family:sans-serif">⟳ Refresh models</span>
+                    </button>
                 </div>
+                <p class="text-xs text-muted mb-3">Each tier uses a different model. Tier 1 observes, Tier 2 investigates and applies safe fixes, Tier 3 performs full remediation.</p>
+                {{template "modelFields" .}}
             </div>
 
             {{/* Dry run */}}
@@ -104,6 +86,57 @@
                     {{end}}
                 </div>
             </div>
+        </div>
+    </div>
+</div>
+{{end}}
+
+{{/*
+  modelFields renders the three per-tier model controls. When upstream discovery
+  is available, each tier is a <select> populated from the discovered models
+  (with the current value preserved as an option even if not discovered).
+  Otherwise it falls back to a free-text <input>. This block is the HTMX swap
+  target for the refresh control.
+  Governing: SPEC-0035 REQ "Configuration UI Model Selection", REQ "Graceful Degradation".
+*/}}
+{{define "modelFields"}}
+<div id="model-fields" aria-live="polite">
+    {{if not .DiscoveryAvailable}}
+    <p class="text-xs text-muted mb-3">Upstream model discovery is unavailable (ANTHROPIC_BASE_URL unset or unreachable). Enter model names manually.</p>
+    {{end}}
+    <div class="grid grid-cols-1 md:grid-cols-3 gap-4">
+        <div>
+            <label for="tier1_model" class="block text-xs text-muted mb-1">Tier 1 &mdash; Observe</label>
+            {{if .DiscoveryAvailable}}
+            <select id="tier1_model" name="tier1_model" class="input-field w-full">
+                {{if and .Tier1Model (not (contains .AvailableModels .Tier1Model))}}<option value="{{.Tier1Model}}" selected>{{.Tier1Model}}</option>{{end}}
+                {{range .AvailableModels}}<option value="{{.}}" {{if eq . $.Tier1Model}}selected{{end}}>{{.}}</option>{{end}}
+            </select>
+            {{else}}
+            <input type="text" id="tier1_model" name="tier1_model" value="{{.Tier1Model}}" class="input-field w-full" placeholder="model name">
+            {{end}}
+        </div>
+        <div>
+            <label for="tier2_model" class="block text-xs text-muted mb-1">Tier 2 &mdash; Investigate</label>
+            {{if .DiscoveryAvailable}}
+            <select id="tier2_model" name="tier2_model" class="input-field w-full">
+                {{if and .Tier2Model (not (contains .AvailableModels .Tier2Model))}}<option value="{{.Tier2Model}}" selected>{{.Tier2Model}}</option>{{end}}
+                {{range .AvailableModels}}<option value="{{.}}" {{if eq . $.Tier2Model}}selected{{end}}>{{.}}</option>{{end}}
+            </select>
+            {{else}}
+            <input type="text" id="tier2_model" name="tier2_model" value="{{.Tier2Model}}" class="input-field w-full" placeholder="model name">
+            {{end}}
+        </div>
+        <div>
+            <label for="tier3_model" class="block text-xs text-muted mb-1">Tier 3 &mdash; Remediate</label>
+            {{if .DiscoveryAvailable}}
+            <select id="tier3_model" name="tier3_model" class="input-field w-full">
+                {{if and .Tier3Model (not (contains .AvailableModels .Tier3Model))}}<option value="{{.Tier3Model}}" selected>{{.Tier3Model}}</option>{{end}}
+                {{range .AvailableModels}}<option value="{{.}}" {{if eq . $.Tier3Model}}selected{{end}}>{{.}}</option>{{end}}
+            </select>
+            {{else}}
+            <input type="text" id="tier3_model" name="tier3_model" value="{{.Tier3Model}}" class="input-field w-full" placeholder="model name">
+            {{end}}
         </div>
     </div>
 </div>


### PR DESCRIPTION
## Summary

Implements **SPEC-0035: Upstream Model Auto-Discovery**. Claude Ops now discovers the models available on the upstream OpenAI/Anthropic-compatible gateway (LiteLLM, configured via `ANTHROPIC_BASE_URL`) and surfaces them so the operator can assign any discovered model to each escalation tier (`tier1_model`/`tier2_model`/`tier3_model`) from a selectable list, instead of typing model name strings blindly. Falls back to free-text when discovery is unavailable.

The discovery **source** (the upstream gateway at `${ANTHROPIC_BASE_URL}/v1/models`) is deliberately distinct from Claude Ops' **own** served `/v1/models` endpoint (SPEC-0024 / ADR-0020), which advertises the synthetic `claude-ops*` tier IDs.

## What's included

- **`internal/models` (new package):** `Discoverer` queries `${ANTHROPIC_BASE_URL}/v1/models` with `Authorization: Bearer ${ANTHROPIC_API_KEY}`, a 5s bounded timeout, OpenAI list parsing, dedupe+sort, a 5m TTL cache, single-flight refresh, a 1 MiB size-bounded body read, and structured error logging that never leaks the API key.
- **`internal/web/models_handler.go` (new file):** `GET /api/v1/models/available` (and `?refresh=true`) plus `POST /api/v1/models/available/refresh` return the discovered list with freshness metadata (`last_refreshed`, `discovery_available`). When discovery is unavailable they return **200 with an empty list and `discovery_available:false`**, never an error status.
- **Config page (`config.html` + `handlers.go`):** tier1/2/3 fields render as dropdowns populated from the discovered list, preserving the current value even if it isn't discovered; an on-demand **Refresh models** control (HTMX swap, `aria-live="polite"`, `aria-label`) re-queries the gateway; **free-text inputs** are shown when discovery is unavailable. Configuration always renders and saves regardless of discovery state. Any model ID (discovered or manually typed) is accepted for a tier.

## Spec / issues

- Spec: `docs/openspec/specs/upstream-model-discovery/{spec.md,design.md}` (included in this PR)
- Closes #501, #502, #503, #504 — Part of #500

## Coordination with PR #499 (stats endpoint)

This PR was implemented in an isolated worktree and deliberately avoids PR #499's files. It does **not** touch `api/openapi.yaml`, `internal/web/api_handlers.go`, `internal/web/api_types.go`, or `internal/web/api_test.go`. The only overlap is `internal/web/server.go`, where this PR adds a single struct field, one constructor line, one `registerModelRoutes()` call, and a `contains` template helper — all additive; a trivial merge against #499's route additions is expected.

## Validation

- `go build ./...` — OK
- `go vet ./...` — OK
- `go test ./... -count=1 -race` — all packages pass (new tests in `internal/models` and `internal/web`)
- `golangci-lint run` on the new/changed code — **0 issues**

> ⚠️ **Pre-existing lint note:** `golangci-lint run ./...` reports 7 issues that already exist on `main` (in `internal/session/manager.go`, `internal/web/handlers.go`'s `classifyPromptTier`, and `internal/web/webhook_handler_test.go`) — verified by linting a clean `origin/main` checkout. None are introduced by this PR, and they were left untouched to keep this PR focused and avoid colliding with concurrent work. They should be cleaned up separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)