### PR TITLE
chore(lint): fix pre-existing golangci-lint issues

### DIFF
--- a/internal/session/manager.go
+++ b/internal/session/manager.go
@@ -568,7 +568,7 @@ func (m *Manager) runTier(ctx context.Context, tier int, model string, promptFil
 			// Scanner finished naturally within grace period.
 		case <-time.After(5 * time.Second):
 			fmt.Fprintf(os.Stderr, "session %d: stdout pipe still open after process exit, force-closing\n", sessionID)
-			stdoutPipe.Close()
+			_ = stdoutPipe.Close()
 			<-streamDone // Wait for scanner goroutine to finish.
 		}
 
@@ -1289,7 +1289,7 @@ func ParseTimestampedLogLine(line string) (ts time.Time, raw string, hasTS bool)
 func buildHandoffContext(h *Handoff) string {
 	var b strings.Builder
 	b.WriteString("## Escalation Context\n\n")
-	b.WriteString(fmt.Sprintf("Services affected: %s\n\n", strings.Join(h.ServicesAffected, ", ")))
+	fmt.Fprintf(&b, "Services affected: %s\n\n", strings.Join(h.ServicesAffected, ", "))
 
 	if len(h.CheckResults) > 0 {
 		b.WriteString("### Check Results\n\n")
@@ -1536,7 +1536,7 @@ func buildStructuredEscalationContext(resp *AgentResponse) string {
 	b.WriteString("## Escalation Context\n\n")
 
 	if resp.Escalation.Reason != "" {
-		b.WriteString(fmt.Sprintf("**Reason:** %s\n\n", resp.Escalation.Reason))
+		fmt.Fprintf(&b, "**Reason:** %s\n\n", resp.Escalation.Reason)
 	}
 
 	if len(resp.ServicesChecked) > 0 {
@@ -1554,7 +1554,7 @@ func buildStructuredEscalationContext(resp *AgentResponse) string {
 	if len(resp.Escalation.FailedChecks) > 0 {
 		b.WriteString("### Failed Checks\n\n")
 		for _, fc := range resp.Escalation.FailedChecks {
-			b.WriteString(fmt.Sprintf("- %s\n", fc))
+			fmt.Fprintf(&b, "- %s\n", fc)
 		}
 		b.WriteString("\n")
 	}

--- a/internal/web/busy.go
+++ b/internal/web/busy.go
@@ -32,7 +32,7 @@ func generateBusyResponse(ctx context.Context, database *db.DB, apiKey string) s
 	events, _ := database.ListEvents(10, 0, nil, nil)
 
 	var sb strings.Builder
-	sb.WriteString(fmt.Sprintf("You are Claude Ops, an infrastructure monitoring agent currently running a Tier %d monitoring session (session #%d, started %s).\n", session.Tier, session.ID, session.StartedAt))
+	fmt.Fprintf(&sb, "You are Claude Ops, an infrastructure monitoring agent currently running a Tier %d monitoring session (session #%d, started %s).\n", session.Tier, session.ID, session.StartedAt)
 	sb.WriteString("A user has sent a message while you are busy. Write a brief 2–3 sentence first-person response:\n")
 	sb.WriteString("1. Acknowledge that you received their message.\n")
 	sb.WriteString("2. State that you are currently running an active monitoring session.\n")
@@ -44,7 +44,7 @@ func generateBusyResponse(ctx context.Context, database *db.DB, apiKey string) s
 			if e.Service != nil {
 				svc = "[" + *e.Service + "] "
 			}
-			sb.WriteString(fmt.Sprintf("- [%s] %s%s\n", e.Level, svc, e.Message))
+			fmt.Fprintf(&sb, "- [%s] %s%s\n", e.Level, svc, e.Message)
 		}
 	} else {
 		sb.WriteString("3. Let them know you will be available shortly.\n")

--- a/internal/web/handlers.go
+++ b/internal/web/handlers.go
@@ -723,7 +723,7 @@ func classifyPromptTier(ctx context.Context, apiKey, prompt string) int {
 	if err != nil || resp.StatusCode != http.StatusOK {
 		return 1
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	var result struct {
 		Content []struct {

--- a/internal/web/webhook_handler_test.go
+++ b/internal/web/webhook_handler_test.go
@@ -23,13 +23,13 @@ func webhookTestSynthServer(t *testing.T, responseText string, statusCode int) *
 	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if statusCode != 0 && statusCode != http.StatusOK {
 			w.WriteHeader(statusCode)
-			fmt.Fprintf(w, `{"error":{"type":"api_error","message":"upstream error"}}`)
+			_, _ = fmt.Fprintf(w, `{"error":{"type":"api_error","message":"upstream error"}}`)
 			return
 		}
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
 		if responseText == "" {
-			fmt.Fprintf(w, `{"id":"msg_test","content":[],"model":"claude-haiku-4-5-20251001","stop_reason":"end_turn"}`)
+			_, _ = fmt.Fprintf(w, `{"id":"msg_test","content":[],"model":"claude-haiku-4-5-20251001","stop_reason":"end_turn"}`)
 			return
 		}
 		resp := map[string]any{


### PR DESCRIPTION
## Summary

Fixes all pre-existing `golangci-lint` findings on `main` so `golangci-lint run ./...` reports **0 issues**. These were flagged during work on PR #499 / #505 but predate both and belong in their own focused PR (per maintainer request).

**No behavior change** — purely satisfying the linters.

## Fixes (9 findings across 4 files)
- **errcheck** — handle ignored return values:
  - `internal/session/manager.go` — `_ = stdoutPipe.Close()`
  - `internal/web/handlers.go` — `defer func() { _ = resp.Body.Close() }()`
  - `internal/web/webhook_handler_test.go` ×2 — `_, _ = fmt.Fprintf(w, …)`
- **staticcheck QF1012** — `fmt.Fprintf(&b, …)` instead of `b.WriteString(fmt.Sprintf(…))`:
  - `internal/session/manager.go` ×3
  - `internal/web/busy.go` ×2 (these two were initially hidden by golangci-lint's default `max-same-issues` cap and surfaced once the manager.go ones were fixed)

## Verification
- `golangci-lint run ./...` → **0 issues**
- `go build ./...`, `go vet ./...` → clean
- `go test ./... -race` → all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)