### PR TITLE
feat(config,docs): show upstream endpoint on config page; document model discovery + Homepage

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,49 @@ The web dashboard runs on port 8080 and provides:
 
 Sessions can be triggered manually from the dashboard using the "Run Now" button.
 
+## Homepage Integration
+
+Claude Ops exposes a JSON stats endpoint built for dashboards like [Homepage](https://gethomepage.dev). `GET /api/v1/stats` returns the same metrics shown on the TL;DR HUD — total runs, escalations, remediations, success rate, total cost, active memories, critical events (last 24h), and average duration — plus the latest session and the next scheduled run.
+
+Add a [Custom API widget](https://gethomepage.dev/widgets/services/customapi/) to your Homepage `services.yaml`:
+
+```yaml
+- Claude Ops:
+    href: https://claude-ops.example.com
+    icon: sh-claude
+    description: AI infrastructure monitoring
+    widget:
+      type: customapi
+      url: https://claude-ops.example.com/api/v1/stats
+      refreshInterval: 60000
+      mappings:
+        - field:
+            stats: total_runs
+          label: Runs
+          format: number
+        - field:
+            stats: success_rate
+          label: Success
+          format: number
+          scale: 100
+          suffix: "%"
+        - field:
+            stats: total_cost_usd
+          label: Cost
+          format: number
+          prefix: "$"
+        - field:
+            stats: critical_events
+          label: Critical
+          format: number
+```
+
+Notes:
+
+- The endpoint is **unauthenticated** (like `/api/v1/health`), so no API key is needed for the widget.
+- Nested values use Homepage's object `field:` syntax — `stats: total_runs` maps to `stats.total_runs`. `success_rate` is a 0–1 ratio, hence `scale: 100` + `suffix: "%"`.
+- The full response schema (including `last_session` and `next_run`) is documented in the embedded Swagger UI at `/api/docs/`.
+
 ## Configuration
 
 All configuration via environment variables:
@@ -147,7 +190,7 @@ All configuration via environment variables:
 | Variable | Default | Description |
 |----------|---------|-------------|
 | `ANTHROPIC_API_KEY` | *(required)* | Claude API key (or LiteLLM proxy key) |
-| `ANTHROPIC_BASE_URL` | *(Anthropic default)* | Base URL for the API. Set to your LiteLLM/proxy URL (e.g., `https://litellm.example.com`) |
+| `ANTHROPIC_BASE_URL` | *(Anthropic default)* | Base URL for the API. Set to your LiteLLM/proxy URL (e.g., `https://litellm.example.com`). Also enables [upstream model auto-discovery](#upstream-model-auto-discovery). |
 | `CLAUDEOPS_INTERVAL` | `3600` | Seconds between scheduled runs |
 | `CLAUDEOPS_TIER1_MODEL` | `haiku` | Model for health checks (Tier 1) |
 | `CLAUDEOPS_TIER2_MODEL` | `sonnet` | Model for investigation + safe remediation (Tier 2) |
@@ -174,6 +217,17 @@ ANTHROPIC_BASE_URL=https://litellm.example.com
 ```
 
 **Bedrock users:** If your LiteLLM routes to AWS Bedrock, ensure your model deployments use inference profile ARNs (not raw model IDs) and that `drop_params: true` is set to strip unsupported beta headers.
+
+### Upstream model auto-discovery
+
+When `ANTHROPIC_BASE_URL` points at a gateway that exposes a models-list endpoint (e.g. LiteLLM's `/v1/models`), Claude Ops automatically discovers the routable models and offers them as **dropdowns for each tier on the Config page** — so you can assign any backing model (Gemini, DeepSeek, Claude, etc.) to Tier 1/2/3 without typing identifiers by hand.
+
+- The discovered list is cached (5-minute TTL) and can be force-refreshed with the **⟳ Refresh models** control on the Config page.
+- The configured endpoint and its live discovery status are shown in the Config page's **Environment (read-only)** section.
+- Programmatic access: `GET /api/v1/models/available` returns the discovered models with freshness metadata; `POST /api/v1/models/available/refresh` forces a re-query.
+- If `ANTHROPIC_BASE_URL` is unset or the gateway is unreachable, the tier fields gracefully fall back to free-text entry (the API reports `discovery_available: false`).
+
+The discovery source (your upstream gateway) is distinct from Claude Ops' own OpenAI-compatible `/v1/models` endpoint. Governed by SPEC-0035 (Upstream Model Auto-Discovery).
 
 ## Architecture
 

--- a/internal/web/models_handler.go
+++ b/internal/web/models_handler.go
@@ -82,6 +82,11 @@ type configPageData struct {
 	// SPEC-0035 fields:
 	AvailableModels    []string
 	DiscoveryAvailable bool
+	// UpstreamBaseURL is the configured upstream gateway (ANTHROPIC_BASE_URL)
+	// that model discovery queries. Shown read-only on the config page so the
+	// operator can see which endpoint discovery is sourced from. Empty when the
+	// Anthropic default is in use (no gateway configured).
+	UpstreamBaseURL string
 }
 
 // buildConfigPageData assembles the config-page template payload, including the
@@ -106,6 +111,7 @@ func (s *Server) buildConfigPageData(r *http.Request, saved bool) configPageData
 		ChatAPIKey:            os.Getenv("CLAUDEOPS_CHAT_API_KEY"),
 		AvailableModels:       disc.Models,
 		DiscoveryAvailable:    disc.Available,
+		UpstreamBaseURL:       upstreamBaseURL(),
 	}
 }
 

--- a/internal/web/templates/config.html
+++ b/internal/web/templates/config.html
@@ -65,6 +65,8 @@
         <div class="card-base text-sm text-muted">
             <p class="mb-2">These settings are configured via environment variables or CLI flags and cannot be changed at runtime.</p>
             <div class="grid grid-cols-1 md:grid-cols-2 gap-2 font-mono text-xs">
+                {{/* Governing: SPEC-0035 — the upstream gateway model discovery queries */}}
+                <div>ANTHROPIC_BASE_URL</div><div class="text-charcoal">{{if .UpstreamBaseURL}}{{.UpstreamBaseURL}} <span class="{{if .DiscoveryAvailable}}text-green-700{{else}}text-muted{{end}}">({{if .DiscoveryAvailable}}model discovery active{{else}}discovery unreachable{{end}})</span>{{else}}(Anthropic default — model discovery disabled){{end}}</div>
                 <div>CLAUDEOPS_STATE_DIR</div><div class="text-charcoal">{{.StateDir}}</div>
                 <div>CLAUDEOPS_RESULTS_DIR</div><div class="text-charcoal">{{.ResultsDir}}</div>
                 <div>CLAUDEOPS_REPOS_DIR</div><div class="text-charcoal">{{.ReposDir}}</div>


### PR DESCRIPTION
## Summary

Follow-ups to the model auto-discovery feature (#505 / SPEC-0035), addressing two gaps:

1. **The config page never showed the discovery endpoint.** `ANTHROPIC_BASE_URL` was read from env (`upstreamBaseURL()`) and used for discovery, but wasn't displayed anywhere. It's now surfaced in the config page's read-only **Environment** section, with live discovery status.
2. **No user-facing docs for dynamic models.** Only the spec existed — `README.md` had nothing about auto-discovery, and there was no Homepage integration guide.

## Changes

**Config page** (`internal/web/models_handler.go`, `templates/config.html`)
- Add `UpstreamBaseURL` to the config page payload, populated from `ANTHROPIC_BASE_URL`.
- Show it as the first row of **Environment (read-only)**, e.g.:
  - `https://litellm.example.com (model discovery active)` — green when reachable
  - `(discovery unreachable)` when set but down; `(Anthropic default — model discovery disabled)` when unset.

**Docs** (`README.md`)
- New **Upstream model auto-discovery** section: per-tier dropdowns, ⟳ refresh, `GET /api/v1/models/available` (+ refresh), graceful degradation, and the source-vs-own-endpoint distinction.
- New **Homepage Integration** section: a copy-paste [Custom API widget](https://gethomepage.dev/widgets/services/customapi/) for `GET /api/v1/stats` (Runs / Success% / Cost / Critical), with notes on the unauthenticated endpoint and nested-field mapping.
- Env table: link `ANTHROPIC_BASE_URL` to the new section.

## Verification
- `go build`, `go vet` — clean
- `golangci-lint run` — **0 issues**
- `go test ./... -race` — all pass
- Template parses (config + models web tests pass)

Governing: SPEC-0035 (Upstream Model Auto-Discovery), SPEC-0021 (stats endpoint)

🤖 Generated with [Claude Code](https://claude.com/claude-code)